### PR TITLE
Block compromised LiteLLM versions and bump to v1.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "scrappy-ai"
-version = "1.2.0"
+version = "1.3.0"
 description = "A context-aware coding assistant for everyone. Students, learners, anyone who doesn't want to pay for subscriptions."
 readme = "README.md"
 license = {text = "MIT"}
@@ -27,7 +27,7 @@ classifiers = [
 ]
 dependencies = [
     "instructor>=1.7.0",
-    "litellm>=1.80.10",
+    "litellm>=1.80.10,!=1.82.7,!=1.82.8",
     "python-dotenv>=1.0.0",
     "openai>=1.0.0",
     "click>=8.0.0",


### PR DESCRIPTION
Exclude litellm 1.82.7–1.82.8 (supply chain attack, GHSA-xp8h-5cgw-fghr).

Closes #9

## Description

Brief description of the changes in this PR.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have run `pytest tests/` and all tests pass

## Coverage

Current test run: `python -m pytest tests/ --cov=src --cov-report=term-missing`

Does this PR maintain or improve coverage? [ ] Yes / [ ] No

## Related Issues

Closes #(issue number)
