### PR TITLE
Add provider health workflow and config validation tests

### DIFF
--- a/.github/workflows/provider-health.yml
+++ b/.github/workflows/provider-health.yml
@@ -1,0 +1,65 @@
+name: Provider Health Check
+
+on:
+  # Run daily to catch model deprecations / config drift
+  schedule:
+    - cron: '0 8 * * *'
+  # Run on PRs that touch provider config
+  pull_request:
+    paths:
+      - 'src/scrappy/orchestrator/litellm_config.py'
+      - 'src/scrappy/orchestrator/provider_definitions.py'
+      - 'src/scrappy/orchestrator/model_selection.py'
+      - 'pyproject.toml'
+  # Manual trigger
+  workflow_dispatch:
+
+jobs:
+  # ---------------------------------------------------------------
+  # Tier 1: No secrets — validates config parses and is consistent
+  # ---------------------------------------------------------------
+  config-validation:
+    name: Validate provider config
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - uses: actions/setup-python@v5
+      with:
+        python-version: "3.11"
+        cache: 'pip'
+
+    - name: Install dependencies
+      run: pip install -e .[dev]
+
+    - name: Validate config
+      run: python -m pytest tests/providers/test_provider_config.py::TestConfigParsesCorrectly -v
+
+  # ---------------------------------------------------------------
+  # Tier 2: With secrets — pings every configured model
+  # Models are discovered from build_model_list, not hardcoded.
+  # Missing secrets → individual tests skip gracefully.
+  # ---------------------------------------------------------------
+  model-health:
+    name: Ping configured models
+    runs-on: ubuntu-latest
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    steps:
+    - uses: actions/checkout@v4
+
+    - uses: actions/setup-python@v5
+      with:
+        python-version: "3.11"
+        cache: 'pip'
+
+    - name: Install dependencies
+      run: pip install -e .[dev]
+
+    - name: Ping all configured models
+      env:
+        CEREBRAS_API_KEY: ${{ secrets.CEREBRAS_API_KEY }}
+        GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
+        SAMBANOVA_API_KEY: ${{ secrets.SAMBANOVA_API_KEY }}
+        GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+      run: python -m pytest tests/providers/test_provider_config.py::test_configured_model_responds -v
+      timeout-minutes: 5

--- a/src/scrappy/orchestrator/litellm_config.py
+++ b/src/scrappy/orchestrator/litellm_config.py
@@ -149,6 +149,16 @@ MODEL_METADATA: dict[str, ModelMetadata] = {
         rpd=14400,
         tpm=60000,
     ),
+    "cerebras/zai-glm-4.7": ModelMetadata(
+        model_id="cerebras/zai-glm-4.7",
+        provider="cerebras",
+        group="instruct",
+        context_length=131072,  # 128k context
+        speed=SpeedRank.FAST,
+        quality=QualityRank.VERY_GOOD,
+        rpd=14400,
+        tpm=60000,
+    ),
 
     # Groq
     "groq/moonshotai/kimi-k2-instruct": ModelMetadata(

--- a/tests/providers/test_provider_config.py
+++ b/tests/providers/test_provider_config.py
@@ -1,0 +1,177 @@
+"""
+Provider config validation and health checks.
+
+Tier 1 (no secrets): config parses, models are recognized by litellm, groups valid.
+Tier 2 (with secrets): ping each provider with a minimal completion request.
+"""
+
+import os
+import pytest
+from unittest.mock import MagicMock
+
+
+# ---------------------------------------------------------------------------
+# Tier 1: Config validation (no API keys needed)
+# ---------------------------------------------------------------------------
+
+class TestConfigParsesCorrectly:
+    """Validate that provider/model config is internally consistent."""
+
+    def test_model_metadata_has_required_fields(self):
+        from scrappy.orchestrator.litellm_config import MODEL_METADATA
+        for model_id, meta in MODEL_METADATA.items():
+            assert meta.model_id == model_id, f"Key/id mismatch: {model_id}"
+            assert meta.provider in {"cerebras", "groq", "gemini", "sambanova"}
+            assert meta.group in {"fast", "chat", "instruct"}
+            assert meta.context_length > 0
+            assert meta.rpd > 0
+            assert meta.tpm > 0
+
+    def test_every_provider_has_definition(self):
+        from scrappy.orchestrator.litellm_config import MODEL_METADATA
+        from scrappy.orchestrator.provider_definitions import PROVIDERS
+
+        providers_in_models = {m.provider for m in MODEL_METADATA.values()}
+        for provider in providers_in_models:
+            assert provider in PROVIDERS, f"Provider {provider} in MODEL_METADATA but not in PROVIDERS"
+
+    def test_provider_env_vars_are_defined(self):
+        from scrappy.orchestrator.provider_definitions import PROVIDERS
+        for name, defn in PROVIDERS.items():
+            assert defn.env_var, f"Provider {name} has no env_var"
+            assert defn.env_var.endswith("_API_KEY"), f"Provider {name} env_var should end with _API_KEY"
+
+    def test_build_model_list_with_all_keys(self):
+        """build_model_list should return models for all groups when all keys present."""
+        from scrappy.orchestrator.litellm_config import build_model_list
+
+        mock_keys = MagicMock()
+        mock_keys.get_key.return_value = "fake-key-for-testing"
+
+        model_list = build_model_list(mock_keys)
+        groups = {m["model_name"] for m in model_list}
+        assert "fast" in groups, "No fast models configured"
+        assert "chat" in groups, "No chat models configured"
+        assert "instruct" in groups, "No instruct models configured"
+
+    def test_build_model_list_empty_without_keys(self):
+        """build_model_list should return empty list when no keys configured."""
+        from scrappy.orchestrator.litellm_config import build_model_list
+
+        mock_keys = MagicMock()
+        mock_keys.get_key.return_value = None
+
+        model_list = build_model_list(mock_keys)
+        assert model_list == []
+
+    def test_litellm_recognizes_model_ids(self):
+        """Every model ID should be parseable by litellm (provider/model format)."""
+        from scrappy.orchestrator.litellm_config import MODEL_METADATA
+
+        for model_id in MODEL_METADATA:
+            parts = model_id.split("/", 1)
+            assert len(parts) == 2, f"Model ID {model_id} not in provider/model format"
+            provider, model = parts
+            assert len(provider) > 0
+            assert len(model) > 0
+
+    def test_each_group_has_at_least_two_providers(self):
+        """Each model group should have fallback options from multiple providers."""
+        from scrappy.orchestrator.litellm_config import MODEL_METADATA
+
+        group_providers: dict[str, set[str]] = {}
+        for meta in MODEL_METADATA.values():
+            group_providers.setdefault(meta.group, set()).add(meta.provider)
+
+        for group, providers in group_providers.items():
+            assert len(providers) >= 2, (
+                f"Group '{group}' only has providers: {providers}. "
+                f"Add a fallback provider for resilience."
+            )
+
+    def test_build_model_list_all_models_in_metadata(self):
+        """Every model in build_model_list must exist in MODEL_METADATA."""
+        from scrappy.orchestrator.litellm_config import build_model_list, MODEL_METADATA
+
+        mock_keys = MagicMock()
+        mock_keys.get_key.return_value = "fake-key"
+
+        model_list = build_model_list(mock_keys)
+        metadata_ids = set(MODEL_METADATA.keys())
+
+        missing = []
+        for entry in model_list:
+            model_id = entry["litellm_params"]["model"]
+            if model_id not in metadata_ids:
+                missing.append(model_id)
+
+        assert not missing, (
+            f"Models in build_model_list but missing from MODEL_METADATA: {missing}. "
+            f"Add metadata or remove the model from the router config."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tier 2: Verify every configured model actually works with its provider
+# ---------------------------------------------------------------------------
+
+# Map provider prefix to the env var that holds its key
+_PROVIDER_KEY_MAP = {
+    "cerebras": "CEREBRAS_API_KEY",
+    "groq": "GROQ_API_KEY",
+    "gemini": "GEMINI_API_KEY",
+    "sambanova": "SAMBANOVA_API_KEY",
+}
+
+
+def _get_key(name: str) -> str:
+    """Get API key at runtime (after dotenv has loaded)."""
+    key = os.environ.get(name, "")
+    if not key:
+        pytest.skip(f"{name} not set")
+    return key
+
+
+def _ping_model(model_id: str, api_key: str):
+    """Send a minimal completion to verify litellm can reach this specific model."""
+    import litellm
+
+    litellm.suppress_debug_info = True
+    litellm.set_verbose = False
+
+    response = litellm.completion(
+        model=model_id,
+        messages=[{"role": "user", "content": "Say OK"}],
+        max_tokens=5,
+        api_key=api_key,
+    )
+    content = response.choices[0].message.content
+    assert content is not None and len(content) > 0, f"Empty response from {model_id}"
+
+
+def _collect_configured_models():
+    """Build parametrized list of (model_id, env_var) from the real router config."""
+    from scrappy.orchestrator.litellm_config import build_model_list
+    mock_keys = MagicMock()
+    mock_keys.get_key.return_value = "fake-key"
+
+    seen = set()
+    params = []
+    for entry in build_model_list(mock_keys):
+        model_id = entry["litellm_params"]["model"]
+        if model_id in seen:
+            continue
+        seen.add(model_id)
+
+        provider = model_id.split("/", 1)[0]
+        env_var = _PROVIDER_KEY_MAP.get(provider)
+        if env_var:
+            params.append(pytest.param(model_id, env_var, id=model_id))
+
+    return params
+
+
+@pytest.mark.parametrize("model_id,env_var", _collect_configured_models())
+def test_configured_model_responds(model_id, env_var):
+    """Each model in build_model_list should return a valid response."""
+    _ping_model(model_id, _get_key(env_var))


### PR DESCRIPTION
Foundation for the self-healing providers epic (scrappy-2awo). Adds config validation that runs on every PR plus a scheduled model-health ping that uses real API keys when secrets are present.

Workflow (.github/workflows/provider-health.yml):
- Tier 1 (config-validation): runs on every PR that touches provider config, no secrets needed. Validates MODEL_METADATA structure, provider definitions, and that build_model_list stays in sync with metadata.
- Tier 2 (model-health): runs on schedule (daily 08:00 UTC) and workflow_dispatch. Pings every configured model with a minimal completion to detect deprecations, auth failures, and account-side issues. Does not gate PRs.

Tests (tests/providers/test_provider_config.py):
- test_model_metadata_has_required_fields: every entry has provider, group, context_length, rpd, tpm
- test_every_provider_has_definition: providers in metadata also exist in PROVIDERS
- test_provider_env_vars_are_defined: every provider declares an env_var ending in _API_KEY
- test_build_model_list_with_all_keys: all groups populated when keys present
- test_build_model_list_empty_without_keys: no models without keys
- test_litellm_recognizes_model_ids: every ID parses as provider/model
- test_each_group_has_at_least_two_providers: each group has fallback options (resilience)
- test_build_model_list_all_models_in_metadata: catches drift between router config and static metadata
- test_configured_model_responds (Tier 2): parametrized ping for every configured model

Drift fix:
- Add cerebras/zai-glm-4.7 to MODEL_METADATA. The model is configured in build_model_list as an instruct fallback (litellm_config.py:363) and listed in MODEL_PRIORITIES (model_selection.py:56) but had no metadata entry. Without metadata, ModelSelectionService.select() with a min_context filter would silently drop this model from the candidate list (model_selection.py:246-249) - so this was both a display gap and a routing bug.

Known Tier 2 signal at time of commit:
- sambanova/Meta-Llama-3.1-8B-Instruct returns 'A payment method is required' for the local key. Real provider-side issue, surfaced correctly. Tier 2 is informational and does not gate PRs.

Closes scrappy-2awo.

## Description

Brief description of the changes in this PR.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have run `pytest tests/` and all tests pass

## Coverage

Current test run: `python -m pytest tests/ --cov=src --cov-report=term-missing`

Does this PR maintain or improve coverage? [ ] Yes / [ ] No

## Related Issues

Closes #(issue number)
