### PR TITLE
Add cerebras/zai-glm-4.7 to MODEL_METADATA

### DIFF
--- a/src/scrappy/orchestrator/litellm_config.py
+++ b/src/scrappy/orchestrator/litellm_config.py
@@ -149,6 +149,16 @@ MODEL_METADATA: dict[str, ModelMetadata] = {
         rpd=14400,
         tpm=60000,
     ),
+    "cerebras/zai-glm-4.7": ModelMetadata(
+        model_id="cerebras/zai-glm-4.7",
+        provider="cerebras",
+        group="instruct",
+        context_length=131072,  # 128k context
+        speed=SpeedRank.FAST,
+        quality=QualityRank.VERY_GOOD,
+        rpd=14400,
+        tpm=60000,
+    ),
 
     # Groq
     "groq/moonshotai/kimi-k2-instruct": ModelMetadata(


### PR DESCRIPTION
The model is configured in build_model_list() (litellm_config.py:363) as an instruct fallback and listed in MODEL_PRIORITIES (model_selection.py:56), but had no entry in MODEL_METADATA.

Without metadata, ModelSelectionService.select(min_context=...) silently drops this model from the candidate list at model_selection.py:246-249, which means routing skips it whenever a context-window filter is in play. Display surfaces (/status, /limits) also lose visibility of the model.

Values match the established Cerebras instruct profile (gpt-oss-120b): 128k context, FAST speed, VERY_GOOD quality, 14400 RPD, 60000 TPM.

## Description

Brief description of the changes in this PR.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have run `pytest tests/` and all tests pass

## Coverage

Current test run: `python -m pytest tests/ --cov=src --cov-report=term-missing`

Does this PR maintain or improve coverage? [ ] Yes / [ ] No

## Related Issues

Closes #(issue number)
