### PR TITLE
Fix scrappy-g5mx: make CLI conversation_store injectable (no __init__…

### DIFF
--- a/src/scrappy/cli/core.py
+++ b/src/scrappy/cli/core.py
@@ -25,6 +25,7 @@ from .utils.session_utils import display_previous_session_detected
 from .utils.cli_factory import initialize_cli_handlers, create_conversation_store
 from .error_recovery import graceful_degrade
 from .logging import get_logger
+from scrappy.infrastructure.persistence import ConversationStoreProtocol
 from scrappy.infrastructure.theme import ThemeProtocol, DEFAULT_THEME
 
 
@@ -41,7 +42,8 @@ class CLI:
         io: Optional[CLIIOProtocol] = None,
         orchestrator: Optional[AgentOrchestrator] = None,
         state_manager: Optional[PlanStateManager] = None,
-        theme: Optional[ThemeProtocol] = None
+        theme: Optional[ThemeProtocol] = None,
+        conversation_store: Optional[ConversationStoreProtocol] = None
     ):
         """
         Initialize CLI with orchestrator and component handlers (dependencies only - NO side effects).
@@ -62,6 +64,9 @@ class CLI:
             orchestrator: Injectable orchestrator instance (default: creates new AgentOrchestrator)
             state_manager: Injectable state manager (default: creates new PlanStateManager)
             theme: Theme for styling. Defaults to DEFAULT_THEME.
+            conversation_store: Injectable persistence store (default: creates one
+                via create_conversation_store, which performs filesystem I/O).
+                Inject a store (or fake) to keep construction side effect free.
         """
         # Store config for factory methods and initialization
         self._brain = brain
@@ -79,8 +84,13 @@ class CLI:
         # Initialize state manager for plan tracking
         self.state_manager = state_manager or self._create_default_state_manager()
 
-        # Create conversation store for persistence
-        conversation_store = create_conversation_store(self.orchestrator)
+        # Create conversation store for persistence (injectable; the default path
+        # performs filesystem I/O, so tests inject a store to keep __init__ side
+        # effect free). Default on `is None` rather than truthiness: this dependency
+        # is Protocol-typed, so an implementation with a falsy __bool__/__len__ must
+        # not be silently replaced (matches SessionContext's `is not None` check).
+        if conversation_store is None:
+            conversation_store = create_conversation_store(self.orchestrator)
 
         # Load previous conversation history from store (token-budgeted)
         loaded_history = []

--- a/src/scrappy/cli/core.py
+++ b/src/scrappy/cli/core.py
@@ -96,7 +96,7 @@ class CLI:
         loaded_history = []
         self._session_is_stale = False
 
-        if conversation_store:
+        if conversation_store is not None:
             loaded_history = conversation_store.get_recent(token_budget=8000)
 
             # Check staleness for LLM context injection (helps LLM know context may be outdated)

--- a/tests/cli/test_phase8_theme_integration.py
+++ b/tests/cli/test_phase8_theme_integration.py
@@ -7,17 +7,15 @@ Verifies that:
 - Theme flows from config through to CLI components
 """
 
-import pytest
 from unittest.mock import MagicMock, patch
 
 from scrappy.cli.cli_config import CLIConfig
+from scrappy.infrastructure.persistence import ConversationStoreProtocol
 from scrappy.infrastructure.theme import (
     ScrappyTheme,
     LightTheme,
     CustomTheme,
-    NoColorTheme,
     DEFAULT_THEME,
-    ThemeProtocol,
 )
 
 
@@ -179,6 +177,12 @@ class TestCLICoreTheme:
             "agent_mgr": MagicMock(),
         }
 
+    def _mock_store(self):
+        """Conversation store double that loads no history (no filesystem I/O)."""
+        store = MagicMock(spec=ConversationStoreProtocol)
+        store.get_recent.return_value = []
+        return store
+
     def test_cli_stores_theme(self):
         """CLI should store the theme."""
         from scrappy.cli.core import CLI
@@ -190,7 +194,7 @@ class TestCLICoreTheme:
             with patch.object(CLI, "_create_default_io") as mock_io:
                 mock_io.return_value = MagicMock()
                 with patch("scrappy.cli.core.initialize_cli_handlers", return_value=self._mock_handlers()):
-                    cli = CLI(theme=theme)
+                    cli = CLI(theme=theme, conversation_store=self._mock_store())
                     assert cli._theme is theme
 
     def test_cli_uses_default_theme(self):
@@ -202,8 +206,31 @@ class TestCLICoreTheme:
             with patch.object(CLI, "_create_default_io") as mock_io:
                 mock_io.return_value = MagicMock()
                 with patch("scrappy.cli.core.initialize_cli_handlers", return_value=self._mock_handlers()):
-                    cli = CLI()
+                    cli = CLI(conversation_store=self._mock_store())
                     assert cli._theme is DEFAULT_THEME
+
+    def test_injected_conversation_store_skips_default_io(self):
+        """Injecting a store bypasses create_conversation_store, so __init__ does no
+        filesystem I/O.
+
+        Regression guard for scrappy-g5mx: with a mocked orchestrator and the default
+        store path, the constructor wrote .scrappy/config.json to a Mock-derived path,
+        leaking junk files into CWD. The injectable seam must short-circuit that.
+        """
+        from scrappy.cli.core import CLI
+
+        with patch.object(CLI, "_create_default_orchestrator") as mock_orch:
+            mock_orch.return_value = MagicMock()
+            with patch.object(CLI, "_create_default_io") as mock_io:
+                mock_io.return_value = MagicMock()
+                with patch("scrappy.cli.core.initialize_cli_handlers", return_value=self._mock_handlers()):
+                    with patch("scrappy.cli.core.create_conversation_store") as mock_create:
+                        # Benign return so a regression (unconditional create) still
+                        # constructs cleanly and fails at the assertion below, not via
+                        # an incidental error in history loading.
+                        mock_create.return_value = self._mock_store()
+                        CLI(conversation_store=self._mock_store())
+                        mock_create.assert_not_called()
 
 
 


### PR DESCRIPTION
… I/O leak)

CLI.__init__ documents "dependencies only - NO side effects" but hard-created the one dependency that does I/O: create_conversation_store writes .scrappy/config.json during construction. When a test mocked the orchestrator, that write resolved to a Mock-derived path and leaked junk files (<MagicMock ...>, None) into the repo root.

Make conversation_store injectable with a factory default, matching its four siblings (io/orchestrator/state_manager/theme): inject a store double and the constructor performs no filesystem I/O. The two leaking theme tests now inject such a double. Adds a fail-when-broken guard asserting an injected store bypasses create_conversation_store. Also drops 3 pre-existing unused imports in the touched test file.

Default on `is None` rather than truthiness (cross-family review): this dependency is Protocol-typed, so a store with a falsy __bool__/__len__ must not be silently replaced; matches SessionContext's downstream `is not None` check. Store double is spec'd to ConversationStoreProtocol to document the contract.

Deferring the default-path I/O out of __init__ entirely (into initialize()) remains separate debt.

## Description

Brief description of the changes in this PR.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have run `pytest tests/` and all tests pass

## Coverage

Current test run: `python -m pytest tests/ --cov=src --cov-report=term-missing`

Does this PR maintain or improve coverage? [ ] Yes / [ ] No

## Related Issues

Closes #(issue number)
