### PR TITLE
Make real-terminal harness readiness wait diagnostic on app/child death

### DIFF
--- a/tests/integration/linux_terminal_harness.py
+++ b/tests/integration/linux_terminal_harness.py
@@ -14,7 +14,14 @@ from typing import Mapping
 
 import pytest
 
-from .real_terminal_harness import RealTerminalHarnessProtocol, RealTerminalSessionSpec, RelativeSelection
+from .real_terminal_harness import (
+    CapturedStream,
+    LaunchLiveness,
+    RealTerminalHarnessProtocol,
+    RealTerminalSessionSpec,
+    RelativeSelection,
+    wait_for_ready_file,
+)
 
 
 LINUX_REQUIRED_TOOLS = ("Xephyr", "xterm", "xdotool", "xclip")
@@ -78,16 +85,6 @@ def _find_free_display_number(
     raise LinuxHarnessError("Unable to find a free X display number for Xephyr")
 
 
-def _wait_for_file(path: Path, *, timeout_seconds: float, description: str) -> None:
-    """Wait for a file-based readiness marker produced by the launched app."""
-    deadline = time.time() + timeout_seconds
-    while time.time() < deadline:
-        if path.exists():
-            return
-        time.sleep(0.1)
-    raise LinuxHarnessError(f"Timed out waiting for {description} at {path}")
-
-
 class LinuxTerminalHarness(RealTerminalHarnessProtocol):
     """Linux implementation using Xephyr, xterm, xdotool, and xclip."""
 
@@ -100,6 +97,8 @@ class LinuxTerminalHarness(RealTerminalHarnessProtocol):
         self._cached_display_env: dict[str, str] | None = None
         self._xephyr_process: subprocess.Popen[str] | None = None
         self._xterm_process: subprocess.Popen[str] | None = None
+        self._xephyr_stderr: CapturedStream | None = None
+        self._xterm_stderr: CapturedStream | None = None
         self._window_id: int | None = None
 
     def launch(self, session: RealTerminalSessionSpec) -> None:
@@ -113,6 +112,7 @@ class LinuxTerminalHarness(RealTerminalHarnessProtocol):
         display_number = _find_free_display_number()
         self._display = f":{display_number}"
         self._cached_display_env = self._build_display_env(session.env)
+        self._xephyr_stderr = CapturedStream.create("scrappy-xephyr-")
         self._xephyr_process = subprocess.Popen(
             [
                 "Xephyr",
@@ -124,10 +124,11 @@ class LinuxTerminalHarness(RealTerminalHarnessProtocol):
                 "-noreset",
             ],
             stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
+            stderr=self._xephyr_stderr.handle,
         )
         self._wait_for_display_socket(display_number)
 
+        self._xterm_stderr = CapturedStream.create("scrappy-xterm-")
         self._xterm_process = subprocess.Popen(
             [
                 "xterm",
@@ -143,7 +144,7 @@ class LinuxTerminalHarness(RealTerminalHarnessProtocol):
             cwd=str(session.fixture_repo),
             env=self._cached_display_env,
             stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
+            stderr=self._xterm_stderr.handle,
         )
         self._window_id = self._find_window_id(session.title)
         self.append_debug_event(
@@ -155,13 +156,43 @@ class LinuxTerminalHarness(RealTerminalHarnessProtocol):
         )
 
     def wait_until_ready(self, timeout_seconds: float) -> None:
-        """Wait for the app's file-based readiness signal."""
+        """Wait for readiness, failing fast if xterm/the app dies before signaling."""
         session = self._require_session()
-        _wait_for_file(
-            session.ready_file,
+        wait_for_ready_file(
+            ready_file=session.ready_file,
+            probe=self.probe_launched_app,
+            drain_diagnostics=self.drain_launch_diagnostics,
             timeout_seconds=timeout_seconds,
-            description="scrappy readiness signal",
+            error_factory=LinuxHarnessError,
         )
+
+    def probe_launched_app(self) -> LaunchLiveness:
+        """Report liveness from the xterm child that hosts the launched app.
+
+        ``xterm -e python ...`` exits when the launched python process exits, so xterm
+        terminating is the app's death signal for this harness. The reported exit code
+        is xterm's own (which does not always mirror the app's), but death itself is
+        what makes the readiness wait fail fast instead of blocking.
+        """
+        process = self._xterm_process
+        if process is None:
+            return LaunchLiveness(alive=True)
+        code = process.poll()
+        if code is None:
+            return LaunchLiveness(alive=True)
+        return LaunchLiveness(alive=False, exit_code=code)
+
+    def drain_launch_diagnostics(self) -> str:
+        """Return the captured xterm process-stderr tail.
+
+        This is xterm's own stderr (X protocol/display/font errors that explain a
+        failed launch), not the launched app's stdout/stderr, which xterm routes to its
+        PTY. It is the diagnostic that was previously discarded to DEVNULL.
+        """
+        captured = self._xterm_stderr
+        if captured is None:
+            return ""
+        return captured.read_tail()
 
     def clear_clipboard(self) -> None:
         """Clear the X11 CLIPBOARD selection on the nested display."""
@@ -296,6 +327,21 @@ class LinuxTerminalHarness(RealTerminalHarnessProtocol):
             self._terminate_process(xephyr_process)
             self.append_debug_event("xephyr_closed", pid=xephyr_process.pid, display=self._display)
 
+        for captured in (self._xterm_stderr, self._xephyr_stderr):
+            if captured is not None:
+                captured.cleanup()
+        self._xterm_stderr = None
+        self._xephyr_stderr = None
+
+    def _stderr_suffix(self, captured: CapturedStream | None) -> str:
+        """Format a captured-stderr tail for inclusion in a launch-failure message."""
+        if captured is None:
+            return ""
+        tail = captured.read_tail().strip()
+        if not tail:
+            return ""
+        return f"\ncaptured stderr tail:\n{tail}"
+
     def _build_display_env(self, extra_env: Mapping[str, str] | None = None) -> dict[str, str]:
         """Build the environment for processes that run inside the nested display."""
         session = self._require_session()
@@ -340,7 +386,10 @@ class LinuxTerminalHarness(RealTerminalHarnessProtocol):
                 return
             xephyr_process = self._xephyr_process
             if xephyr_process is not None and xephyr_process.poll() is not None:
-                raise LinuxHarnessError(f"Xephyr exited before opening display {self._display}")
+                raise LinuxHarnessError(
+                    f"Xephyr exited (code {xephyr_process.returncode}) before opening "
+                    f"display {self._display}" + self._stderr_suffix(self._xephyr_stderr)
+                )
             time.sleep(0.1)
         raise LinuxHarnessError(f"Timed out waiting for Xephyr display {self._display}")
 
@@ -356,7 +405,10 @@ class LinuxTerminalHarness(RealTerminalHarnessProtocol):
                 return int(result.stdout.strip().splitlines()[0])
             xterm_process = self._xterm_process
             if xterm_process is not None and xterm_process.poll() is not None:
-                raise LinuxHarnessError(f"xterm exited before window discovery for {title!r}")
+                raise LinuxHarnessError(
+                    f"xterm exited (code {xterm_process.returncode}) before window "
+                    f"discovery for {title!r}" + self._stderr_suffix(self._xterm_stderr)
+                )
             time.sleep(0.1)
         raise LinuxHarnessError(f"Timed out waiting for xterm window titled {title!r}")
 

--- a/tests/integration/linux_terminal_harness.py
+++ b/tests/integration/linux_terminal_harness.py
@@ -85,6 +85,29 @@ def _find_free_display_number(
     raise LinuxHarnessError("Unable to find a free X display number for Xephyr")
 
 
+def build_app_launch_command(
+    venv_python: Path, entry_module: str, app_stderr_path: Path
+) -> list[str]:
+    """Build the ``xterm -e`` command that runs the app with its stderr captured.
+
+    xterm routes a child's stderr to its PTY, so an app crash (for example a Python
+    import error before readiness) would otherwise be invisible to the harness. The
+    launch is wrapped in ``sh -c 'exec ... 2>>file'`` so the app's stderr is appended
+    to a captured file while stdout stays on the PTY and the terminal UI still renders.
+    ``exec`` replaces the shell with python, so the process tree stays ``xterm -> python``
+    and liveness polling of the xterm child is unaffected. Paths are passed as shell
+    positional arguments to avoid quoting issues.
+    """
+    return [
+        "sh",
+        "-c",
+        'exec "$0" -m "$1" 2>>"$2"',
+        str(venv_python),
+        entry_module,
+        str(app_stderr_path),
+    ]
+
+
 class LinuxTerminalHarness(RealTerminalHarnessProtocol):
     """Linux implementation using Xephyr, xterm, xdotool, and xclip."""
 
@@ -99,6 +122,7 @@ class LinuxTerminalHarness(RealTerminalHarnessProtocol):
         self._xterm_process: subprocess.Popen[str] | None = None
         self._xephyr_stderr: CapturedStream | None = None
         self._xterm_stderr: CapturedStream | None = None
+        self._app_stderr: CapturedStream | None = None
         self._window_id: int | None = None
 
     def launch(self, session: RealTerminalSessionSpec) -> None:
@@ -129,6 +153,7 @@ class LinuxTerminalHarness(RealTerminalHarnessProtocol):
         self._wait_for_display_socket(display_number)
 
         self._xterm_stderr = CapturedStream.create("scrappy-xterm-")
+        self._app_stderr = CapturedStream.create("scrappy-app-")
         self._xterm_process = subprocess.Popen(
             [
                 "xterm",
@@ -137,9 +162,9 @@ class LinuxTerminalHarness(RealTerminalHarnessProtocol):
                 "-T",
                 session.title,
                 "-e",
-                str(session.venv_python),
-                "-m",
-                session.entry_module,
+                *build_app_launch_command(
+                    session.venv_python, session.entry_module, self._app_stderr.path
+                ),
             ],
             cwd=str(session.fixture_repo),
             env=self._cached_display_env,
@@ -183,16 +208,20 @@ class LinuxTerminalHarness(RealTerminalHarnessProtocol):
         return LaunchLiveness(alive=False, exit_code=code)
 
     def drain_launch_diagnostics(self) -> str:
-        """Return the captured xterm process-stderr tail.
+        """Return the launched app's captured stderr, falling back to xterm's own.
 
-        This is xterm's own stderr (X protocol/display/font errors that explain a
-        failed launch), not the launched app's stdout/stderr, which xterm routes to its
-        PTY. It is the diagnostic that was previously discarded to DEVNULL.
+        The app runs as ``xterm -e sh -c 'exec python ... 2>>file'``, so a Python crash
+        before readiness (the motivating app-death case) lands in the app-stderr file
+        rather than being lost to the PTY. When the app wrote nothing, fall back to
+        xterm's own stderr (X protocol/display/font errors that explain a failed launch),
+        which is the diagnostic that was previously discarded to DEVNULL.
         """
-        captured = self._xterm_stderr
-        if captured is None:
-            return ""
-        return captured.read_tail()
+        app = self._app_stderr
+        app_tail = app.read_tail() if app is not None else ""
+        if app_tail.strip():
+            return app_tail
+        xterm = self._xterm_stderr
+        return xterm.read_tail() if xterm is not None else ""
 
     def clear_clipboard(self) -> None:
         """Clear the X11 CLIPBOARD selection on the nested display."""
@@ -327,11 +356,12 @@ class LinuxTerminalHarness(RealTerminalHarnessProtocol):
             self._terminate_process(xephyr_process)
             self.append_debug_event("xephyr_closed", pid=xephyr_process.pid, display=self._display)
 
-        for captured in (self._xterm_stderr, self._xephyr_stderr):
+        for captured in (self._xterm_stderr, self._xephyr_stderr, self._app_stderr):
             if captured is not None:
                 captured.cleanup()
         self._xterm_stderr = None
         self._xephyr_stderr = None
+        self._app_stderr = None
 
     def _stderr_suffix(self, captured: CapturedStream | None) -> str:
         """Format a captured-stderr tail for inclusion in a launch-failure message."""

--- a/tests/integration/macos_terminal_harness.py
+++ b/tests/integration/macos_terminal_harness.py
@@ -13,7 +13,13 @@ from typing import Any
 
 import pytest
 
-from .real_terminal_harness import RealTerminalHarnessProtocol, RealTerminalSessionSpec, RelativeSelection
+from .real_terminal_harness import (
+    LaunchLiveness,
+    RealTerminalHarnessProtocol,
+    RealTerminalSessionSpec,
+    RelativeSelection,
+    wait_for_ready_file,
+)
 
 
 MACOS_REQUIRED_TOOLS = ("osascript", "pbcopy", "pbpaste")
@@ -51,16 +57,6 @@ def _parse_launch_identity(output: str) -> tuple[int, str]:
     return int(window_id_text), session_id
 
 
-def _wait_for_file(path: Path, *, timeout_seconds: float, description: str) -> None:
-    """Wait for a file-based readiness marker produced by the launched app."""
-    deadline = time.time() + timeout_seconds
-    while time.time() < deadline:
-        if path.exists():
-            return
-        time.sleep(0.1)
-    raise MacOSHarnessError(f"Timed out waiting for {description} at {path}")
-
-
 class MacOSTerminalHarness(RealTerminalHarnessProtocol):
     """macOS implementation using iTerm2 session ownership and frontmost-app guards."""
 
@@ -88,8 +84,9 @@ class MacOSTerminalHarness(RealTerminalHarnessProtocol):
             [
                 'tell application "iTerm2"',
                 "activate",
-                f'set newWindow to (create window with default profile command "{_escape_applescript_string(shell_command)}")',
+                "set newWindow to (create window with default profile)",
                 "set newSession to current session of current tab of newWindow",
+                f'tell newSession to write text "{_escape_applescript_string(shell_command)}"',
                 'return ((id of newWindow) as string) & "|" & (unique id of newSession)',
                 "end tell",
             ]
@@ -102,12 +99,81 @@ class MacOSTerminalHarness(RealTerminalHarnessProtocol):
         )
 
     def wait_until_ready(self, timeout_seconds: float) -> None:
-        """Wait for the app's file-based readiness signal."""
+        """Wait for readiness, failing fast if the iTerm2 session dies before signaling."""
         session = self._require_session()
-        _wait_for_file(
-            session.ready_file,
+        wait_for_ready_file(
+            ready_file=session.ready_file,
+            probe=self.probe_launched_app,
+            drain_diagnostics=self.drain_launch_diagnostics,
             timeout_seconds=timeout_seconds,
-            description="scrappy readiness signal",
+            # osascript polling is costly; a coarser interval keeps the wait cheap.
+            poll_interval_seconds=0.25,
+            error_factory=MacOSHarnessError,
+        )
+
+    def probe_launched_app(self) -> LaunchLiveness:
+        """Report liveness via ownership of the launched iTerm2 window.
+
+        macOS launches the app inside an iTerm2 session (``exec python -m ...``) rather
+        than as a direct child, so there is no process handle to poll and no exit code
+        to read. Death is detected by the owned window disappearing when the session's
+        process ends; the exit code is therefore reported as unknown (None). Profiles
+        configured to keep the session open after the process exits cannot be detected
+        this way and fall through to the timeout path (still reported with diagnostics).
+        """
+        if self._window_id is None:
+            return LaunchLiveness(alive=True)
+        if self._owned_window_exists():
+            return LaunchLiveness(alive=True)
+        return LaunchLiveness(alive=False, exit_code=None)
+
+    def drain_launch_diagnostics(self) -> str:
+        """Return the visible iTerm2 session text as launch diagnostics.
+
+        The launched app's stderr is rendered into the iTerm2 session rather than a
+        capturable pipe, so the on-screen text (which includes any startup traceback)
+        is the best available diagnostic.
+        """
+        session_unique_id = self._session_unique_id
+        if session_unique_id is None:
+            return ""
+        try:
+            return self._read_owned_session_text(session_unique_id)
+        except MacOSHarnessError:
+            return ""
+
+    def _owned_window_exists(self) -> bool:
+        """Return True if the recorded iTerm2 window id is still present."""
+        window_id = self._require_window_id()
+        output = self._run_osascript(
+            [
+                'tell application "iTerm2"',
+                "repeat with aWindow in windows",
+                f'if id of aWindow is {window_id} then return "yes"',
+                "end repeat",
+                'return "no"',
+                "end tell",
+            ],
+            check=False,
+        )
+        return output.strip() == "yes"
+
+    def _read_owned_session_text(self, session_unique_id: str) -> str:
+        """Return the visible text of the owned iTerm2 session, or empty if it is gone."""
+        return self._run_osascript(
+            [
+                'tell application "iTerm2"',
+                "repeat with aWindow in windows",
+                "repeat with aTab in tabs of aWindow",
+                "repeat with aSession in sessions of aTab",
+                f'if unique id of aSession is "{session_unique_id}" then return (text of aSession)',
+                "end repeat",
+                "end repeat",
+                "end repeat",
+                'return ""',
+                "end tell",
+            ],
+            check=False,
         )
 
     def clear_clipboard(self) -> None:

--- a/tests/integration/real_terminal_harness.py
+++ b/tests/integration/real_terminal_harness.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Mapping, Protocol, runtime_checkable
+import tempfile
+import time
+from typing import BinaryIO, Callable, Mapping, Protocol, runtime_checkable
 
 
 @dataclass(frozen=True)
@@ -26,6 +28,169 @@ class RealTerminalSessionSpec:
     ready_file: Path
     env: Mapping[str, str] = field(default_factory=dict)
     entry_module: str = "scrappy.cli.commands"
+
+
+DEFAULT_READY_POLL_INTERVAL_SECONDS = 0.1
+DEFAULT_DIAGNOSTICS_TAIL_CHARS = 4000
+
+
+@dataclass(frozen=True)
+class LaunchLiveness:
+    """Snapshot of whether a launched app is still running.
+
+    ``alive`` is True while the launched process is running. When it is False the app
+    has exited; ``exit_code`` carries the platform-reported exit status when the driver
+    can observe it, or None when the platform can detect death but not the numeric code
+    (for example macOS, where the app runs inside an iTerm2 session rather than as a
+    direct child process).
+    """
+
+    alive: bool
+    exit_code: int | None = None
+
+
+class ReadinessTimeout(RuntimeError):
+    """Default error raised when an app never signals readiness.
+
+    Drivers pass their own ``error_factory`` to :func:`wait_for_ready_file` so the
+    platform-specific error type is preserved for existing callers; this class is only
+    the fallback when no factory is supplied.
+    """
+
+
+@dataclass
+class CapturedStream:
+    """A temp file capturing a child process's stderr for later diagnostics.
+
+    A temp file (rather than a pipe) is used deliberately: the child can write an
+    unbounded amount of stderr without the parent having to drain it, so teardown can
+    never deadlock on a full pipe buffer.
+    """
+
+    path: Path
+    handle: BinaryIO
+
+    @classmethod
+    def create(cls, prefix: str) -> CapturedStream:
+        """Open a fresh temp file ready to receive a child's stderr stream."""
+        # The write handle is owned by the caller, which closes it during teardown.
+        tmp = tempfile.NamedTemporaryFile(
+            mode="wb", prefix=prefix, suffix=".stderr.log", delete=False
+        )
+        return cls(path=Path(tmp.name), handle=tmp)
+
+    def read_tail(self, limit: int = DEFAULT_DIAGNOSTICS_TAIL_CHARS) -> str:
+        """Return the last ``limit`` characters captured so far, decoded leniently."""
+        try:
+            self.handle.flush()
+        except (OSError, ValueError):
+            pass
+        try:
+            data = self.path.read_bytes()
+        except OSError:
+            return ""
+        return data.decode("utf-8", errors="replace")[-limit:]
+
+    def cleanup(self) -> None:
+        """Close the write handle and remove the temp file."""
+        try:
+            self.handle.close()
+        except (OSError, ValueError):
+            pass
+        try:
+            self.path.unlink()
+        except OSError:
+            pass
+
+
+def _format_not_ready(
+    *,
+    description: str,
+    ready_file: Path,
+    liveness: LaunchLiveness,
+    diagnostics: str,
+    waited_seconds: float,
+) -> str:
+    """Build a diagnostic message for a failed readiness wait."""
+    if not liveness.alive:
+        code = "unknown" if liveness.exit_code is None else liveness.exit_code
+        headline = (
+            f"Launched app exited (code {code}) before writing {description} "
+            f"at {ready_file} after {waited_seconds:.1f}s"
+        )
+    else:
+        headline = (
+            f"Timed out after {waited_seconds:.1f}s waiting for {description} at {ready_file}; "
+            "launched app was still alive"
+        )
+    tail = diagnostics.strip()
+    if tail:
+        return f"{headline}\ncaptured stderr tail:\n{tail}"
+    return f"{headline}\ncaptured stderr tail: <none captured>"
+
+
+def _safe_drain(drain_diagnostics: Callable[[], str]) -> str:
+    """Drain diagnostics without letting a drain failure mask the readiness error."""
+    try:
+        text = drain_diagnostics()
+    except Exception as exc:  # diagnostics must never hide the real readiness failure
+        return f"<diagnostics drain failed: {exc!r}>"
+    if not text:
+        return ""
+    return text[-DEFAULT_DIAGNOSTICS_TAIL_CHARS:]
+
+
+def wait_for_ready_file(
+    *,
+    ready_file: Path,
+    probe: Callable[[], LaunchLiveness],
+    drain_diagnostics: Callable[[], str],
+    timeout_seconds: float,
+    description: str = "scrappy readiness signal",
+    poll_interval_seconds: float = DEFAULT_READY_POLL_INTERVAL_SECONDS,
+    error_factory: Callable[[str], Exception] = ReadinessTimeout,
+) -> None:
+    """Block until ``ready_file`` appears, the launched app dies, or time runs out.
+
+    This is the single shared readiness primitive for every platform driver. Each tick
+    checks the readiness marker first and then the liveness probe, so a launched app
+    that crashes before writing the marker fails fast (instead of a blind timeout) and
+    the raised error carries the app exit code plus a captured-stderr tail. Drivers
+    supply ``probe`` and ``drain_diagnostics`` (and their own ``error_factory``); this
+    primitive only composes them and never reaches into driver internals.
+    """
+    start = time.monotonic()
+    deadline = start + timeout_seconds
+    while True:
+        if ready_file.exists():
+            return
+        liveness = probe()
+        if not liveness.alive:
+            # The app may have written the marker and exited within the same tick.
+            if ready_file.exists():
+                return
+            raise error_factory(
+                _format_not_ready(
+                    description=description,
+                    ready_file=ready_file,
+                    liveness=liveness,
+                    diagnostics=_safe_drain(drain_diagnostics),
+                    waited_seconds=time.monotonic() - start,
+                )
+            )
+        if time.monotonic() >= deadline:
+            if ready_file.exists():
+                return
+            raise error_factory(
+                _format_not_ready(
+                    description=description,
+                    ready_file=ready_file,
+                    liveness=liveness,
+                    diagnostics=_safe_drain(drain_diagnostics),
+                    waited_seconds=time.monotonic() - start,
+                )
+            )
+        time.sleep(poll_interval_seconds)
 
 
 @dataclass(frozen=True)
@@ -58,6 +223,21 @@ class RealTerminalHarnessProtocol(Protocol):
 
     def wait_until_ready(self, timeout_seconds: float) -> None:
         """Block until the launched app emits a readiness signal."""
+
+    def probe_launched_app(self) -> LaunchLiveness:
+        """Report whether the launched app is still running and its exit code if known.
+
+        Composed by :func:`wait_for_ready_file` so readiness waits fail fast when the
+        app dies instead of blocking until the timeout. Returns ``alive=True`` before
+        launch so the primitive treats an un-launched harness as still pending.
+        """
+
+    def drain_launch_diagnostics(self) -> str:
+        """Return a captured-stderr (or equivalent) tail for readiness failure messages.
+
+        Composed by :func:`wait_for_ready_file`. Returns an empty string when the
+        platform has nothing captured rather than raising.
+        """
 
     def clear_clipboard(self) -> None:
         """Clear the active clipboard for this harness session."""

--- a/tests/integration/test_harness_app_diagnostics.py
+++ b/tests/integration/test_harness_app_diagnostics.py
@@ -1,0 +1,89 @@
+"""Tests for capturing the launched app's stderr in the real-terminal harnesses.
+
+Review follow-up to the readiness-diagnostics work (scrappy-harness-ready-blind-
+timeout-z9l6): the fail-fast path previously reported ``<none captured>`` for the
+motivating case, a Python crash before readiness, because the app's stderr was lost
+(it goes to the xterm PTY on Linux, and was never captured on Windows).
+
+These tests are GUI-free and run on macOS: the Linux launch-command test really runs
+``sh`` + ``python`` to prove the redirect routes child stderr to a file; the drain
+tests exercise the diagnostic-selection logic directly. The full Xephyr / Windows
+console launch paths remain unverifiable from macOS.
+"""
+
+from pathlib import Path
+import subprocess
+import sys
+
+from .linux_terminal_harness import LinuxTerminalHarness, build_app_launch_command
+from .real_terminal_harness import CapturedStream
+from .windows_console_harness import WindowsOwnedConsoleHarness
+
+
+def test_linux_app_launch_command_routes_child_stderr_to_file(tmp_path: Path) -> None:
+    """The Linux launch wrapper must send the app's stderr to the capture file, not
+    the inherited stderr stream, so a crash-before-ready leaves a diagnostic behind."""
+    stderr_file = tmp_path / "app.stderr.log"
+    command = build_app_launch_command(
+        Path(sys.executable), "scrappy_definitely_missing_module_xyz", stderr_file
+    )
+
+    result = subprocess.run(command, capture_output=True, text=True)
+
+    # `python -m <missing>` writes its error to stderr and exits non-zero.
+    assert result.returncode != 0
+    captured = stderr_file.read_text(encoding="utf-8")
+    assert "scrappy_definitely_missing_module_xyz" in captured
+    # The child's stderr was redirected into the file, so the parent stream is empty.
+    # This is exactly the diagnostic that was previously lost to the PTY.
+    assert result.stderr == ""
+
+
+def test_linux_drain_prefers_app_stderr_then_falls_back_to_xterm() -> None:
+    """drain_launch_diagnostics surfaces the app traceback when present, and otherwise
+    falls back to xterm's own stderr (launch-phase X/display errors)."""
+    harness = LinuxTerminalHarness()
+    assert harness.drain_launch_diagnostics() == ""
+
+    xterm = CapturedStream.create("test-xterm-")
+    app = CapturedStream.create("test-app-")
+    try:
+        harness._xterm_stderr = xterm
+        harness._app_stderr = app
+
+        # App wrote nothing yet -> fall back to xterm stderr.
+        xterm.handle.write(b"xterm: cannot open display :99\n")
+        xterm.handle.flush()
+        assert "cannot open display" in harness.drain_launch_diagnostics()
+
+        # App stderr present -> it wins over the xterm fallback.
+        app.handle.write(b"Traceback: ImportError onnxruntime boom\n")
+        app.handle.flush()
+        result = harness.drain_launch_diagnostics()
+        assert "onnxruntime boom" in result
+        assert "cannot open display" not in result
+    finally:
+        xterm.cleanup()
+        app.cleanup()
+
+
+def test_windows_drain_prefers_app_stderr_then_falls_back_to_debug_log(tmp_path: Path) -> None:
+    """The Windows drain returns the captured app stderr when present, otherwise the
+    structured debug-event trail."""
+    harness = WindowsOwnedConsoleHarness()
+    harness.debug_log = ["event: console_launched", "event: ready_wait_started"]
+
+    # No capture file -> debug-log fallback.
+    assert "ready_wait_started" in harness.drain_launch_diagnostics()
+
+    stderr_file = tmp_path / "app.stderr.log"
+    stderr_file.write_text("", encoding="utf-8")
+    harness._app_stderr_path = stderr_file
+    # Empty capture file -> still the debug-log fallback.
+    assert "ready_wait_started" in harness.drain_launch_diagnostics()
+
+    # Captured app stderr present -> it wins over the debug log.
+    stderr_file.write_text("Traceback: ImportError onnxruntime boom\n", encoding="utf-8")
+    result = harness.drain_launch_diagnostics()
+    assert "onnxruntime boom" in result
+    assert "ready_wait_started" not in result

--- a/tests/integration/test_real_terminal_readiness.py
+++ b/tests/integration/test_real_terminal_readiness.py
@@ -1,0 +1,214 @@
+"""Reproduce-first tests for the shared real-terminal readiness primitive.
+
+These exercise :func:`wait_for_ready_file` through a minimal fake harness that
+implements only the two new Protocol methods (``probe_launched_app`` and
+``drain_launch_diagnostics``), backed by a real child process and a real
+``CapturedStream``. No GUI terminal, X server, or Windows console is required, so the
+whole module runs on macOS in the dogfood worktree.
+
+The bug under repair: the old per-driver ``_wait_for_file`` helper polled only the
+ready_file against a deadline and never checked whether the launched app was still
+alive, so an app that crashed before writing the marker (for example the 3.14-venv
+onnxruntime startup crash) produced a blind, diagnostically empty timeout.
+``test_legacy_ready_file_only_wait_is_blind`` reproduces that failure mode;
+``test_app_death_fails_fast_with_exit_code_and_stderr`` locks in the fix.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+import sys
+import time
+
+import pytest
+
+from .real_terminal_harness import (
+    CapturedStream,
+    LaunchLiveness,
+    ReadinessTimeout,
+    wait_for_ready_file,
+)
+
+
+class _FakeLaunchedApp:
+    """Stand-in implementing only the readiness Protocol methods, backed by a child.
+
+    It drives the exact composition path the real drivers use: a liveness probe over a
+    real process and a diagnostics drain over a real captured-stderr temp file.
+    """
+
+    def __init__(
+        self,
+        *,
+        stderr_text: str,
+        exit_code: int,
+        ready_file: Path | None,
+        delay_seconds: float = 0.0,
+    ) -> None:
+        self._capture = CapturedStream.create("scrappy-readytest-")
+        script_lines = ["import sys, time", f"time.sleep({delay_seconds!r})"]
+        if ready_file is not None:
+            script_lines.append(f"open({str(ready_file)!r}, 'w').close()")
+        script_lines.append(f"sys.stderr.write({stderr_text!r})")
+        script_lines.append("sys.stderr.flush()")
+        script_lines.append(f"sys.exit({exit_code})")
+        self._process = subprocess.Popen(
+            [sys.executable, "-c", "\n".join(script_lines)],
+            stdout=subprocess.DEVNULL,
+            stderr=self._capture.handle,
+        )
+
+    def probe_launched_app(self) -> LaunchLiveness:
+        code = self._process.poll()
+        if code is None:
+            return LaunchLiveness(alive=True)
+        return LaunchLiveness(alive=False, exit_code=code)
+
+    def drain_launch_diagnostics(self) -> str:
+        return self._capture.read_tail()
+
+    def cleanup(self) -> None:
+        try:
+            self._process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            self._process.kill()
+            self._process.wait(timeout=5)
+        self._capture.cleanup()
+
+
+def _legacy_ready_file_only_wait(path: Path, *, timeout_seconds: float) -> None:
+    """The pre-fix readiness wait: poll only the ready_file against a deadline.
+
+    Reproduced verbatim (minus the platform error type) to demonstrate the original
+    diagnostic blindness that the shared primitive removes.
+    """
+    deadline = time.monotonic() + timeout_seconds
+    while time.monotonic() < deadline:
+        if path.exists():
+            return
+        time.sleep(0.02)
+    raise RuntimeError(f"Timed out waiting for scrappy readiness signal at {path}")
+
+
+def test_legacy_ready_file_only_wait_is_blind(tmp_path: Path) -> None:
+    """Before the fix: a dead app produces a full-duration, diagnostic-free timeout."""
+    ready_file = tmp_path / "never_written.ready"
+    app = _FakeLaunchedApp(stderr_text="onnxruntime import boom\n", exit_code=3, ready_file=None)
+    app.cleanup()  # the app is already dead (and reaped) well before the wait starts
+
+    timeout_seconds = 0.5
+    start = time.monotonic()
+    with pytest.raises(RuntimeError) as excinfo:
+        _legacy_ready_file_only_wait(ready_file, timeout_seconds=timeout_seconds)
+    elapsed = time.monotonic() - start
+
+    # The blindness: it burned the whole timeout despite the app being long dead...
+    assert elapsed >= timeout_seconds * 0.8
+    # ...and the message carries none of the new primitive's diagnostics.
+    message = str(excinfo.value)
+    assert "exited" not in message
+    assert "captured stderr tail" not in message
+    assert "boom" not in message
+
+
+def test_app_death_fails_fast_with_exit_code_and_stderr(tmp_path: Path) -> None:
+    """After the fix: a dead app fails fast, with the exit code and stderr tail."""
+    ready_file = tmp_path / "never_written.ready"
+    app = _FakeLaunchedApp(stderr_text="onnxruntime import boom\n", exit_code=3, ready_file=None)
+    try:
+        timeout_seconds = 5.0
+        start = time.monotonic()
+        with pytest.raises(ReadinessTimeout) as excinfo:
+            wait_for_ready_file(
+                ready_file=ready_file,
+                probe=app.probe_launched_app,
+                drain_diagnostics=app.drain_launch_diagnostics,
+                timeout_seconds=timeout_seconds,
+                poll_interval_seconds=0.02,
+            )
+        elapsed = time.monotonic() - start
+    finally:
+        app.cleanup()
+
+    # Fail-fast: nowhere near the timeout.
+    assert elapsed < timeout_seconds / 2
+    message = str(excinfo.value)
+    assert "code 3" in message
+    assert "boom" in message
+
+
+def test_custom_error_factory_preserves_platform_error_type(tmp_path: Path) -> None:
+    """Drivers keep their own error type via error_factory (backward compatibility)."""
+
+    class _PlatformError(RuntimeError):
+        pass
+
+    ready_file = tmp_path / "never_written.ready"
+    app = _FakeLaunchedApp(stderr_text="startup failed\n", exit_code=7, ready_file=None)
+    try:
+        with pytest.raises(_PlatformError) as excinfo:
+            wait_for_ready_file(
+                ready_file=ready_file,
+                probe=app.probe_launched_app,
+                drain_diagnostics=app.drain_launch_diagnostics,
+                timeout_seconds=5.0,
+                poll_interval_seconds=0.02,
+                error_factory=_PlatformError,
+            )
+    finally:
+        app.cleanup()
+    assert "code 7" in str(excinfo.value)
+
+
+def test_ready_file_present_returns_immediately(tmp_path: Path) -> None:
+    """A marker already on disk returns without consulting liveness."""
+    ready_file = tmp_path / "ready.now"
+    ready_file.write_text("ok", encoding="utf-8")
+
+    def _explode() -> LaunchLiveness:  # pragma: no cover - must not be called
+        raise AssertionError("probe should not run when the marker already exists")
+
+    wait_for_ready_file(
+        ready_file=ready_file,
+        probe=_explode,
+        drain_diagnostics=lambda: "",
+        timeout_seconds=5.0,
+    )
+
+
+def test_ready_file_written_during_wait_succeeds(tmp_path: Path) -> None:
+    """A marker that appears mid-wait resolves the wait successfully."""
+    ready_file = tmp_path / "deferred.ready"
+    app = _FakeLaunchedApp(
+        stderr_text="",
+        exit_code=0,
+        ready_file=ready_file,
+        delay_seconds=0.3,
+    )
+    try:
+        wait_for_ready_file(
+            ready_file=ready_file,
+            probe=app.probe_launched_app,
+            drain_diagnostics=app.drain_launch_diagnostics,
+            timeout_seconds=5.0,
+            poll_interval_seconds=0.02,
+        )
+    finally:
+        app.cleanup()
+    assert ready_file.exists()
+
+
+def test_marker_written_then_immediate_exit_is_treated_as_ready(tmp_path: Path) -> None:
+    """If the app writes the marker and exits in the same instant, that is success."""
+    ready_file = tmp_path / "ready_then_exit.ready"
+    app = _FakeLaunchedApp(stderr_text="", exit_code=0, ready_file=ready_file)
+    app.cleanup()  # guarantee the process is fully dead before we wait
+    wait_for_ready_file(
+        ready_file=ready_file,
+        probe=lambda: LaunchLiveness(alive=False, exit_code=0),
+        drain_diagnostics=lambda: "",
+        timeout_seconds=5.0,
+        poll_interval_seconds=0.02,
+    )
+    assert ready_file.exists()

--- a/tests/integration/windows_console_harness.py
+++ b/tests/integration/windows_console_harness.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import re
 import subprocess
 import sys
+import tempfile
 import time
 import types
 from typing import Any
@@ -17,6 +18,7 @@ import pyperclip
 import pytest
 
 from .real_terminal_harness import (
+    DEFAULT_DIAGNOSTICS_TAIL_CHARS,
     LaunchLiveness,
     RealTerminalHarnessProtocol,
     RealTerminalSessionSpec,
@@ -319,6 +321,17 @@ class OwnedConsoleWindow:
         if self.process.pid <= 0:
             return
 
+        # The host now exits with the app on a crash (no -NoExit), so by teardown it
+        # may already be gone and its window with it. Reap it directly and skip the
+        # foreground pid-match guard, which would spuriously fail against a missing
+        # window.
+        if self.process.poll() is not None:
+            self.process.wait(timeout=5)
+            self.debug_log.append(
+                f"closed (already exited) pid={self.process.pid} code={self.process.returncode}"
+            )
+            return
+
         foreground_hwnd = self.win32gui.GetForegroundWindow()
         _, window_pid = self.win32process.GetWindowThreadProcessId(self.hwnd)
         if window_pid != self.process.pid:
@@ -367,11 +380,14 @@ def launch_owned_console(
     encoded_script = _encode_powershell_command(
         f"$host.UI.RawUI.WindowTitle = '{safe_title}'\n{script}\n"
     )
+    # No -NoExit: the host must terminate when the launched app exits so that an
+    # app-only crash (Python dying before readiness) ends the host process and is
+    # observable via process liveness. The script ends with `exit $LASTEXITCODE`, so
+    # the host's exit code mirrors the app's.
     process = subprocess.Popen(
         [
             "powershell.exe",
             "-NoLogo",
-            "-NoExit",
             "-EncodedCommand",
             encoded_script,
         ],
@@ -414,6 +430,7 @@ class WindowsOwnedConsoleHarness(RealTerminalHarnessProtocol):
         self._console: OwnedConsoleWindow | None = None
         self._session: RealTerminalSessionSpec | None = None
         self._previous_clipboard: str = ""
+        self._app_stderr_path: Path | None = None
 
     def launch(self, session: RealTerminalSessionSpec) -> None:
         """Launch scrappy in an owned PowerShell console."""
@@ -422,6 +439,16 @@ class WindowsOwnedConsoleHarness(RealTerminalHarnessProtocol):
             _validate_env_var_name(key)
 
         self._previous_clipboard = pyperclip.paste()
+
+        # Capture the launched app's stderr to a file so a Python crash before
+        # readiness is preserved rather than scrolling past in the console. The temp
+        # handle is closed immediately so PowerShell can open the path for writing
+        # (Windows would otherwise raise a sharing violation against an open handle).
+        stderr_tmp = tempfile.NamedTemporaryFile(
+            prefix="scrappy-winapp-", suffix=".stderr.log", delete=False
+        )
+        stderr_tmp.close()
+        self._app_stderr_path = Path(stderr_tmp.name)
 
         launch_script_lines = [
             f"Set-Location -LiteralPath '{_escape_powershell_single_quoted(str(session.fixture_repo))}'",
@@ -434,7 +461,12 @@ class WindowsOwnedConsoleHarness(RealTerminalHarnessProtocol):
             [
                 f"$env:SCRAPPY_INTEGRATION_LOG_PATH = '{_escape_powershell_single_quoted(str(session.debug_log_path))}'",
                 f"$env:SCRAPPY_READY_FILE = '{_escape_powershell_single_quoted(str(session.ready_file))}'",
-                f"& '{_escape_powershell_single_quoted(str(session.venv_python))}' -m {session.entry_module}",
+                # Redirect app stderr to the capture file (stdout stays on the console
+                # so the TUI still renders), then propagate the app's exit code so the
+                # host (launched without -NoExit) dies with the child on a crash.
+                f"& '{_escape_powershell_single_quoted(str(session.venv_python))}' -m {session.entry_module}"
+                f" 2> '{_escape_powershell_single_quoted(str(self._app_stderr_path))}'",
+                "exit $LASTEXITCODE",
             ]
         )
         launch_script = "\n".join(launch_script_lines) + "\n"
@@ -461,12 +493,12 @@ class WindowsOwnedConsoleHarness(RealTerminalHarnessProtocol):
     def probe_launched_app(self) -> LaunchLiveness:
         """Report liveness from the owned PowerShell console process.
 
-        The app runs inside a ``-NoExit`` PowerShell host, so a crash of the inner
-        python process returns control to the PowerShell prompt without ending the
-        host. This probe therefore reliably detects the console process tree dying, but
-        an app-only crash that leaves the host alive cannot be observed here and falls
-        through to the timeout path (still reported with diagnostics). This asymmetry is
-        documented and could not be verified from macOS.
+        The host is launched without ``-NoExit`` and its script ends with
+        ``exit $LASTEXITCODE``, so when the inner python process crashes the host exits
+        with the app's code rather than dropping to a prompt. Polling the host process
+        therefore detects an app-only crash and reports the propagated exit code, which
+        lets the readiness wait fail fast instead of blocking to the timeout. The exit
+        code path could not be verified from macOS.
         """
         console = self._console
         if console is None:
@@ -477,11 +509,21 @@ class WindowsOwnedConsoleHarness(RealTerminalHarnessProtocol):
         return LaunchLiveness(alive=False, exit_code=code)
 
     def drain_launch_diagnostics(self) -> str:
-        """Return a tail of the structured debug log as launch diagnostics.
+        """Return the launched app's captured stderr, falling back to the debug log.
 
-        Windows launches a real console (no captured stderr pipe), so the harness
-        debug-event trail is the best available diagnostic.
+        The app's stderr is redirected to a capture file in the launch script, so a
+        Python crash before readiness lands there. When that file is empty (for example
+        a host/console failure before the app ran), fall back to the structured
+        debug-event trail.
         """
+        path = self._app_stderr_path
+        if path is not None:
+            try:
+                tail = path.read_text(encoding="utf-8", errors="replace")[-DEFAULT_DIAGNOSTICS_TAIL_CHARS:]
+            except OSError:
+                tail = ""
+            if tail.strip():
+                return tail
         if not self.debug_log:
             return ""
         return "\n".join(self.debug_log[-20:])
@@ -566,6 +608,13 @@ class WindowsOwnedConsoleHarness(RealTerminalHarnessProtocol):
                 self.append_debug_event("clipboard_restored")
             except pyperclip.PyperclipException:
                 pass
+            stderr_path = self._app_stderr_path
+            if stderr_path is not None:
+                try:
+                    stderr_path.unlink()
+                except OSError:
+                    pass
+                self._app_stderr_path = None
 
     def _require_console(self) -> OwnedConsoleWindow:
         """Return the launched console or fail if launch() was never called."""

--- a/tests/integration/windows_console_harness.py
+++ b/tests/integration/windows_console_harness.py
@@ -16,7 +16,13 @@ from typing import Any
 import pyperclip
 import pytest
 
-from .real_terminal_harness import RealTerminalHarnessProtocol, RealTerminalSessionSpec, RelativeSelection
+from .real_terminal_harness import (
+    LaunchLiveness,
+    RealTerminalHarnessProtocol,
+    RealTerminalSessionSpec,
+    RelativeSelection,
+    wait_for_ready_file,
+)
 
 
 CONSOLE_READY_TIMEOUT_SECONDS = 20.0
@@ -345,16 +351,6 @@ class OwnedConsoleWindow:
         return path
 
 
-def _wait_for_file(path: Path, *, timeout_seconds: float, description: str) -> None:
-    """Wait for a file-based readiness marker produced by the launched app."""
-    deadline = time.time() + timeout_seconds
-    while time.time() < deadline:
-        if path.exists():
-            return
-        time.sleep(0.1)
-    raise IsolationError(f"Timed out waiting for {description} at {path}")
-
-
 def launch_owned_console(
     *,
     title: str,
@@ -452,13 +448,43 @@ class WindowsOwnedConsoleHarness(RealTerminalHarnessProtocol):
         self.append_debug_event("console_launched", pid=self._console.pid, hwnd=self._console.hwnd)
 
     def wait_until_ready(self, timeout_seconds: float) -> None:
-        """Wait for the app's file-based readiness signal."""
+        """Wait for readiness, failing fast if the owned console dies before signaling."""
         session = self._require_session()
-        _wait_for_file(
-            session.ready_file,
+        wait_for_ready_file(
+            ready_file=session.ready_file,
+            probe=self.probe_launched_app,
+            drain_diagnostics=self.drain_launch_diagnostics,
             timeout_seconds=timeout_seconds,
-            description="scrappy readiness signal",
+            error_factory=IsolationError,
         )
+
+    def probe_launched_app(self) -> LaunchLiveness:
+        """Report liveness from the owned PowerShell console process.
+
+        The app runs inside a ``-NoExit`` PowerShell host, so a crash of the inner
+        python process returns control to the PowerShell prompt without ending the
+        host. This probe therefore reliably detects the console process tree dying, but
+        an app-only crash that leaves the host alive cannot be observed here and falls
+        through to the timeout path (still reported with diagnostics). This asymmetry is
+        documented and could not be verified from macOS.
+        """
+        console = self._console
+        if console is None:
+            return LaunchLiveness(alive=True)
+        code = console.process.poll()
+        if code is None:
+            return LaunchLiveness(alive=True)
+        return LaunchLiveness(alive=False, exit_code=code)
+
+    def drain_launch_diagnostics(self) -> str:
+        """Return a tail of the structured debug log as launch diagnostics.
+
+        Windows launches a real console (no captured stderr pipe), so the harness
+        debug-event trail is the best available diagnostic.
+        """
+        if not self.debug_log:
+            return ""
+        return "\n".join(self.debug_log[-20:])
 
     def clear_clipboard(self) -> None:
         """Clear the Windows clipboard."""

--- a/tests/test_windows_console_harness.py
+++ b/tests/test_windows_console_harness.py
@@ -19,8 +19,17 @@ from tests.integration.windows_console_harness import (
 @dataclass
 class _FakeProcess:
     pid: int
+    poll_result: int | None = None
     wait_calls: int = 0
     kill_calls: int = 0
+
+    @property
+    def returncode(self) -> int | None:
+        return self.poll_result
+
+    def poll(self) -> int | None:
+        """Mirror subprocess.Popen.poll: None while alive, the exit code once done."""
+        return self.poll_result
 
     def wait(self, timeout: float) -> None:
         self.wait_calls += 1
@@ -120,9 +129,10 @@ def _build_owned_console(
     foreground_hwnd: int = 222,
     owner_pid: int = 101,
     foreground_sequence: list[int] | None = None,
+    poll_result: int | None = None,
 ) -> OwnedConsoleWindow:
     return OwnedConsoleWindow(
-        process=_FakeProcess(pid=pid),
+        process=_FakeProcess(pid=pid, poll_result=poll_result),
         title="owned-console",
         hwnd=hwnd,
         window=_FakeWindow(),
@@ -159,6 +169,17 @@ def test_close_refuses_pid_mismatch():
 
     with pytest.raises(IsolationError, match="Refusing teardown because window pid 404 no longer matches owned pid 101"):
         owned.close()
+
+
+def test_close_reaps_already_exited_host_without_pid_check():
+    """A host that already exited (it now propagates an app crash's exit code) is reaped
+    directly, skipping the foreground pid-match guard that would otherwise fail against
+    the already-gone console window."""
+    owned = _build_owned_console(owner_pid=404, poll_result=3)
+
+    owned.close()  # must not raise despite the pid mismatch, because the host is dead
+
+    assert owned.process.wait_calls == 1
 
 
 def test_drag_relative_aborts_when_foreground_changes(monkeypatch: pytest.MonkeyPatch):


### PR DESCRIPTION
The per-driver wait_until_ready() delegated to an identical copy-pasted _wait_for_file() helper that polled only session.ready_file against a deadline. It never checked whether the launched app was still alive, so an app that exited before writing the marker (for example the 3.14-venv onnxruntime startup crash) produced a blind, diagnostically empty timeout on every platform. On Linux it was compounded: Xephyr and xterm stderr went to DEVNULL, so even detected launch-phase deaths reported no cause.

Fix at the contract plus shared-helper layer, not per driver:
- New shared wait_for_ready_file() primitive in real_terminal_harness.py polls the ready_file and a liveness probe each tick, and on app death or timeout fails fast raising via a caller-supplied error_factory carrying the app exit code plus a captured-stderr tail. It composes driver-supplied callables only.
- Two new RealTerminalHarnessProtocol methods, probe_launched_app() and drain_launch_diagnostics(), plus LaunchLiveness and a CapturedStream temp-file helper (temp file, not pipe, so teardown cannot deadlock).
- All three drivers delete their local _wait_for_file and delegate to the primitive, each passing its own error type so existing callers see an unchanged exception type. Linux now captures Xephyr/xterm stderr to temp files instead of DEVNULL, and its launch-phase death errors include the tail.
- New GUI-free reproduce-first test (test_real_terminal_readiness.py): a real child process that exits before writing the marker reproduces the blind timeout and locks in the fail-fast-with-exit-code-and-stderr behavior.

Refs: scrappy-harness-ready-blind-timeout-z9l6

## Description

Brief description of the changes in this PR.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have run `pytest tests/` and all tests pass

## Coverage

Current test run: `python -m pytest tests/ --cov=src --cov-report=term-missing`

Does this PR maintain or improve coverage? [ ] Yes / [ ] No

## Related Issues

Closes #(issue number)
