### PR TITLE
Defer CLI persistence and command-history I/O out of __init__

### DIFF
--- a/src/scrappy/cli/core.py
+++ b/src/scrappy/cli/core.py
@@ -46,7 +46,15 @@ class CLI:
         conversation_store: Optional[ConversationStoreProtocol] = None
     ):
         """
-        Initialize CLI with orchestrator and component handlers (dependencies only - NO side effects).
+        Initialize CLI with orchestrator and component handlers.
+
+        Construction defers all conversation-persistence and command-history
+        filesystem I/O to initialize(): the default conversation store, history
+        loading, staleness checks, and the file-backed command history are created
+        there, not here. Construction is not yet fully side effect free, because the
+        default orchestrator still initializes providers in _create_default_orchestrator
+        (tracked separately as PR-B of scrappy-cli-init-side-effects); inject an
+        orchestrator and a conversation_store to keep construction free of I/O today.
 
         Call initialize() after construction to perform setup and display initialization messages.
 
@@ -84,35 +92,22 @@ class CLI:
         # Initialize state manager for plan tracking
         self.state_manager = state_manager or self._create_default_state_manager()
 
-        # Create conversation store for persistence (injectable; the default path
-        # performs filesystem I/O, so tests inject a store to keep __init__ side
-        # effect free). Default on `is None` rather than truthiness: this dependency
-        # is Protocol-typed, so an implementation with a falsy __bool__/__len__ must
-        # not be silently replaced (matches SessionContext's `is not None` check).
-        if conversation_store is None:
-            conversation_store = create_conversation_store(self.orchestrator)
-
-        # Load previous conversation history from store (token-budgeted)
-        loaded_history = []
+        # Conversation persistence is injectable. Default-store creation, history
+        # loading, and staleness checks all perform filesystem I/O, so they are
+        # deferred to initialize() (see _load_persisted_conversation). __init__ only
+        # holds the injected store (or None) and builds an empty session context so
+        # the attribute exists right after construction; initialize() rebuilds it
+        # with the loaded history. An injected store is held as-is and never
+        # replaced -- it is Protocol-typed, so a falsy __bool__/__len__ must not
+        # trigger a silent default.
+        self._conversation_store = conversation_store
         self._session_is_stale = False
 
-        if conversation_store is not None:
-            loaded_history = conversation_store.get_recent(token_budget=8000)
-
-            # Check staleness for LLM context injection (helps LLM know context may be outdated)
-            if loaded_history:
-                from scrappy.infrastructure.persistence import check_session_staleness, get_stale_context_message
-                last_time = conversation_store.get_last_message_time()
-                if check_session_staleness(last_time):
-                    self._session_is_stale = True
-                    # Inject system message to inform LLM about stale context
-                    loaded_history = [get_stale_context_message()] + loaded_history
-
-        # Create session context for shared state management with loaded history
+        # Create session context for shared state management (history loaded later)
         self.session_context = SessionContext(
-            conversation_history=loaded_history,
+            conversation_history=[],
             conversation_store=conversation_store,
-            was_stale_at_load=self._session_is_stale
+            was_stale_at_load=False,
         )
 
         # Initialize component handlers using factory (pass theme)
@@ -125,9 +120,10 @@ class CLI:
         self.tasks = handlers['tasks']
         self.agent_mgr = handlers['agent_mgr']
 
-        # Initialize command history for CLI mode (enables up/down arrow navigation)
-        # TUI mode uses Textual's TextArea which has its own history
-        self.command_history = CommandHistory(history_file=get_default_history_path())
+        # Command history for CLI mode (enables up/down arrow navigation). Starts
+        # in-memory (no I/O); initialize() loads the file-backed history via
+        # _load_command_history. TUI mode uses Textual's TextArea history.
+        self.command_history = CommandHistory(history_file=None)
         self.input_handler = InputHandler(self.io, history=self.command_history)
 
         # Logger for structured logging
@@ -146,6 +142,10 @@ class CLI:
             self (for method chaining)
         """
 
+        # Perform the filesystem I/O deferred out of __init__.
+        self._load_persisted_conversation()
+        self._load_command_history()
+
         # Silently restore previous session (working memory: files, searches, etc.)
         if offer_session_restore:
             self._silent_session_restore()
@@ -153,6 +153,48 @@ class CLI:
         self.io.echo()
 
         return self
+
+    def _load_persisted_conversation(self) -> None:
+        """Load previously persisted conversation history into the session context.
+
+        Deferred out of __init__ because it performs filesystem I/O: it creates the
+        default conversation store when none was injected, reads token-budgeted
+        recent history, and checks staleness. Rebuilds self.session_context with the
+        loaded history; safe because session_context consumers run after initialize().
+        """
+        store = self._conversation_store
+        if store is None:
+            store = create_conversation_store(self.orchestrator)
+            self._conversation_store = store
+
+        loaded_history: list = []
+        if store is not None:
+            loaded_history = store.get_recent(token_budget=8000)
+
+            # Staleness informs the LLM that restored context may be outdated.
+            if loaded_history:
+                from scrappy.infrastructure.persistence import (
+                    check_session_staleness,
+                    get_stale_context_message,
+                )
+                last_time = store.get_last_message_time()
+                if check_session_staleness(last_time):
+                    self._session_is_stale = True
+                    loaded_history = [get_stale_context_message()] + loaded_history
+
+        self.session_context = SessionContext(
+            conversation_history=loaded_history,
+            conversation_store=store,
+            was_stale_at_load=self._session_is_stale,
+        )
+
+    def _load_command_history(self) -> None:
+        """Load the file-backed command history (creates ~/.scrappy and reads it).
+
+        Deferred out of __init__; until called, an in-memory history is used.
+        """
+        self.command_history = CommandHistory(history_file=get_default_history_path())
+        self.input_handler = InputHandler(self.io, history=self.command_history)
 
     # Factory methods for default dependencies
 

--- a/tests/cli/test_cli_init_no_io.py
+++ b/tests/cli/test_cli_init_no_io.py
@@ -1,0 +1,106 @@
+"""Behavior tests for the CLI constructor I/O-deferral contract.
+
+scrappy-cli-init-side-effects PR-A: CLI.__init__ must not perform conversation
+persistence or command-history filesystem I/O. The default conversation store,
+token-budgeted history load, staleness check, and the file-backed command history
+are created in initialize() instead. These tests pin both halves of that contract:
+__init__ stays I/O-free, and initialize() actually performs the deferred work.
+
+The orchestrator and io are mocked because the default orchestrator still does its
+own provider I/O in __init__ (deferring that is PR-B); these tests isolate the
+persistence/history seam this PR owns.
+"""
+
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+from scrappy.cli.command_history import get_default_history_path
+from scrappy.cli.core import CLI
+from scrappy.infrastructure.persistence import ConversationStoreProtocol
+
+
+def _mock_handlers() -> dict:
+    return {
+        "display": MagicMock(),
+        "session_mgr": MagicMock(),
+        "codebase": MagicMock(),
+        "tasks": MagicMock(),
+        "multiprovider": MagicMock(),
+        "smart": MagicMock(),
+        "agent_mgr": MagicMock(),
+    }
+
+
+def _loaded_store() -> MagicMock:
+    """A store double that reports one prior message at a fresh (non-stale) time."""
+    store = MagicMock(spec=ConversationStoreProtocol)
+    store.get_recent.return_value = [{"role": "user", "content": "hi"}]
+    store.get_last_message_time.return_value = datetime.now()
+    return store
+
+
+def test_init_performs_no_persistence_or_file_history_io():
+    """Constructing the CLI with no injected store must not create the default store,
+    read history, or open the file-backed command history."""
+    with patch.object(CLI, "_create_default_orchestrator", return_value=MagicMock()):
+        with patch.object(CLI, "_create_default_io", return_value=MagicMock()):
+            with patch("scrappy.cli.core.initialize_cli_handlers", return_value=_mock_handlers()):
+                with patch("scrappy.cli.core.create_conversation_store") as mock_create:
+                    with patch("scrappy.cli.core.CommandHistory") as mock_cmd_history:
+                        cli = CLI()
+
+                        # No default store creation and no history read in __init__.
+                        mock_create.assert_not_called()
+                        # Command history built in-memory only (history_file=None).
+                        mock_cmd_history.assert_called_once_with(history_file=None)
+                        # Session context exists but carries no loaded history yet.
+                        assert cli.session_context.conversation_history == []
+
+
+def test_initialize_creates_default_store_and_loads_history():
+    """initialize() must create the default store, load token-budgeted history into
+    the session context, and switch command history to the file-backed path."""
+    store = _loaded_store()
+    with patch.object(CLI, "_create_default_orchestrator", return_value=MagicMock()):
+        with patch.object(CLI, "_create_default_io", return_value=MagicMock()):
+            with patch("scrappy.cli.core.initialize_cli_handlers", return_value=_mock_handlers()):
+                with patch("scrappy.cli.core.create_conversation_store", return_value=store) as mock_create:
+                    with patch("scrappy.cli.core.CommandHistory") as mock_cmd_history:
+                        # Staleness is unrelated to the deferral contract under test
+                        # (and exercised elsewhere); pin it off so the loaded history
+                        # is asserted without a prepended stale-context message.
+                        with patch(
+                            "scrappy.infrastructure.persistence.check_session_staleness",
+                            return_value=False,
+                        ):
+                            cli = CLI()
+                            assert cli.session_context.conversation_history == []
+
+                            cli.initialize(offer_session_restore=False)
+
+                        # Default store created exactly once, during initialize().
+                        mock_create.assert_called_once()
+                        store.get_recent.assert_called_once_with(token_budget=8000)
+                        # Loaded history is now visible on the session context.
+                        assert cli.session_context.conversation_history == [
+                            {"role": "user", "content": "hi"}
+                        ]
+                        # Command history rebuilt against the real default path.
+                        mock_cmd_history.assert_any_call(history_file=get_default_history_path())
+
+
+def test_injected_store_is_never_replaced_by_default():
+    """An injected store is honored in both __init__ and initialize(); the default
+    factory is never consulted (guards the Protocol-typed is-None contract)."""
+    injected = MagicMock(spec=ConversationStoreProtocol)
+    injected.get_recent.return_value = []
+    with patch.object(CLI, "_create_default_orchestrator", return_value=MagicMock()):
+        with patch.object(CLI, "_create_default_io", return_value=MagicMock()):
+            with patch("scrappy.cli.core.initialize_cli_handlers", return_value=_mock_handlers()):
+                with patch("scrappy.cli.core.create_conversation_store") as mock_create:
+                    with patch("scrappy.cli.core.CommandHistory"):
+                        cli = CLI(conversation_store=injected)
+                        cli.initialize(offer_session_restore=False)
+
+                        mock_create.assert_not_called()
+                        injected.get_recent.assert_called_once_with(token_budget=8000)


### PR DESCRIPTION
CLI.__init__ claimed "NO side effects" but performed filesystem I/O: it created the default conversation store (ConversationStore.create mkdirs .scrappy), read token-budgeted history plus a staleness check, and built a file-backed CommandHistory (mkdir ~/.scrappy + read). This violates the AGENTS.md constructor rules and is the first half (PR-A) of scrappy-cli-init-side-effects.

- __init__ now holds the injected conversation store (or None) and builds an empty SessionContext so the attribute exists right after construction; command history starts in-memory (CommandHistory(history_file=None), no I/O).
- initialize() performs the deferred work via two helpers: _load_persisted_conversation creates the default store when none was injected, loads recent history, applies the staleness check, and rebuilds session_context with the loaded history; _load_command_history switches to the file-backed history. Rebuilding session_context is safe because every consumer receives it via _create_command_router / _create_interactive_mode, which run after initialize().
- An injected store is still never replaced (Protocol-typed is-None contract preserved).
- Docstring corrected to the accurate remaining contract: construction is not yet fully side-effect free because the default orchestrator still initializes providers in __init__ (deferring that is the separate PR-B).

New tests/cli/test_cli_init_no_io.py pins both halves: __init__ creates no default store, reads no history, and opens no file-backed command history; initialize() does all three; an injected store is honored without consulting the default factory.

Refs: scrappy-cli-init-side-effects-ygpj (PR-A)

## Description

Brief description of the changes in this PR.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have run `pytest tests/` and all tests pass

## Coverage

Current test run: `python -m pytest tests/ --cov=src --cov-report=term-missing`

Does this PR maintain or improve coverage? [ ] Yes / [ ] No

## Related Issues

Closes #(issue number)
