### PR TITLE
Route warning messages through io.theme.warning

### DIFF
--- a/src/scrappy/cli/core.py
+++ b/src/scrappy/cli/core.py
@@ -301,7 +301,7 @@ class CLI:
             if self.orchestrator.context.is_semantic_search_ready():
                 self.io.secho("Semantic search ready", fg="green")
             else:
-                self.io.secho("Semantic search loading in background...", fg="yellow")
+                self.io.secho("Semantic search loading in background...", fg=self.io.theme.warning)
 
         except Exception:
             # Gracefully handle any errors
@@ -396,11 +396,11 @@ class CLI:
                     io.secho(f"Could not restore session: {error_msg}", fg=io.theme.error)
                     self.logger.warning("Session restore failed", extra={"error": error_msg})
             else:
-                io.secho("Starting fresh session.", fg="yellow")
+                io.secho("Starting fresh session.", fg=io.theme.warning)
                 self.logger.info("User declined session restore")
         except (EOFError, KeyboardInterrupt):
             # Non-interactive environment or user cancelled
-            io.secho("Starting fresh session.", fg="yellow")
+            io.secho("Starting fresh session.", fg=io.theme.warning)
             self.logger.info("Session restore skipped (non-interactive)")
 
     def reinitialize_handlers_with_bridge(

--- a/src/scrappy/cli/setup_wizard.py
+++ b/src/scrappy/cli/setup_wizard.py
@@ -235,7 +235,7 @@ class SetupWizard:
             self._state = WizardState.MENU
             self._show_menu()
         else:
-            self.io.secho("Please type 'ok' to continue or 'q' to quit.", fg="yellow")
+            self.io.secho("Please type 'ok' to continue or 'q' to quit.", fg=self.io.theme.warning)
 
     def _show_disclaimer(self) -> None:
         """Display disclaimer notice."""
@@ -282,7 +282,7 @@ class SetupWizard:
     def _handle_key_input(self, key: str) -> None:
         """Handle API key input."""
         if not key or key.lower() == 'q':
-            self.io.secho("Configuration cancelled.", fg="yellow")
+            self.io.secho("Configuration cancelled.", fg=self.io.theme.warning)
             self._state = WizardState.MENU
             # Screen will handle showing menu after clearing
             return
@@ -382,7 +382,7 @@ Current key: [dim]{masked}[/dim]
             self._state = WizardState.MENU
             # Screen will handle showing menu after clearing
         elif response in ('n', 'no', 'q'):
-            self.io.secho("Removal cancelled.", fg="yellow")
+            self.io.secho("Removal cancelled.", fg=self.io.theme.warning)
             self._state = WizardState.MENU
             # Screen will handle showing menu after clearing
         else:
@@ -466,7 +466,7 @@ Current key: [dim]{masked}[/dim]
                     provider_title = name.replace('_', ' ').title()
                     self.io.secho(f"{provider_title} API key removed.", fg=self.io.theme.success)
                 else:
-                    self.io.secho("Removal cancelled.", fg="yellow")
+                    self.io.secho("Removal cancelled.", fg=self.io.theme.warning)
                 break
             else:
                 self.io.secho("Invalid selection. Enter 1, 2, or q.", fg=self.io.theme.error)
@@ -567,7 +567,7 @@ Current key: [dim]{masked}[/dim]
         # Use TUI prompt (routes through InputCaptureManager)
         key = self.io.prompt(f"Enter {info.env_var}", default="").strip()
         if not key:
-            self.io.secho("Configuration cancelled.", fg="yellow")
+            self.io.secho("Configuration cancelled.", fg=self.io.theme.warning)
             return False
 
         # Validate key format and security


### PR DESCRIPTION
Replace the remaining hard-coded fg="yellow" warning colors in cli/core.py (3) and cli/setup_wizard.py (5) with fg=io.theme.warning, matching the established idiom already used in state_manager.py and display.py. Warning color now follows the active theme instead of a literal, so theme overrides apply consistently. Behavior-preserving (the default/test themes resolve warning to yellow).

Closes scrappy-wiz

## Description

Brief description of the changes in this PR.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have run `pytest tests/` and all tests pass

## Coverage

Current test run: `python -m pytest tests/ --cov=src --cov-report=term-missing`

Does this PR maintain or improve coverage? [ ] Yes / [ ] No

## Related Issues

Closes #(issue number)
