### PR TITLE
Defer default orchestrator initialize() out of CLI.__init__ (PR-B)

### DIFF
--- a/src/scrappy/cli/core.py
+++ b/src/scrappy/cli/core.py
@@ -48,13 +48,13 @@ class CLI:
         """
         Initialize CLI with orchestrator and component handlers.
 
-        Construction defers all conversation-persistence and command-history
-        filesystem I/O to initialize(): the default conversation store, history
-        loading, staleness checks, and the file-backed command history are created
-        there, not here. Construction is not yet fully side effect free, because the
-        default orchestrator still initializes providers in _create_default_orchestrator
-        (tracked separately as PR-B of scrappy-cli-init-side-effects); inject an
-        orchestrator and a conversation_store to keep construction free of I/O today.
+        Construction is side effect free: it assigns dependencies and builds bare
+        objects only. All I/O is deferred to initialize() -- the default
+        orchestrator's provider/brain setup and exploration (orch.initialize), the
+        default conversation store, history loading, staleness checks, and the
+        file-backed command history are all created there, not here. The default
+        orchestrator is built as a bare object in __init__ but not initialized until
+        initialize() runs.
 
         Call initialize() after construction to perform setup and display initialization messages.
 
@@ -86,6 +86,11 @@ class CLI:
 
         # Initialize dependencies using factory methods
         self.io = io or self._create_default_io()
+        # The default orchestrator is built as a bare object here; its provider
+        # probing / brain setup / exploration (orch.initialize) is deferred to
+        # CLI.initialize() so construction performs no I/O. An injected orchestrator
+        # is the caller's responsibility and is never initialized by the CLI.
+        self._orchestrator_is_default = orchestrator is None
         self.orchestrator = orchestrator or self._create_default_orchestrator()
         self.session_start = datetime.now()
 
@@ -142,7 +147,9 @@ class CLI:
             self (for method chaining)
         """
 
-        # Perform the filesystem I/O deferred out of __init__.
+        # Perform the setup/I/O deferred out of __init__. Orchestrator setup runs
+        # first so providers/brain are ready before conversation state loads.
+        self._initialize_orchestrator()
         self._load_persisted_conversation()
         self._load_command_history()
 
@@ -209,20 +216,36 @@ class CLI:
         return UnifiedIO(output_sink=output_adapter, theme=self._theme)
 
     def _create_default_orchestrator(self) -> AgentOrchestrator:
-        """Create default orchestrator."""
-        orch = AgentOrchestrator(
+        """Build the default orchestrator object (no provider setup / I/O).
+
+        Provider probing, brain setup, and exploration are deferred to
+        _initialize_orchestrator(), called from initialize(), so construction
+        stays side effect free. AgentOrchestrator.__init__ itself assigns
+        dependencies only.
+        """
+        return AgentOrchestrator(
             project_path=".",
             context_aware=self._context_aware,
             verbose_selection=self._verbose_selection,
             enable_semantic_search=True,  # Enable for CLI usage
         )
-        orch.initialize(
+
+    def _initialize_orchestrator(self) -> None:
+        """Set up the default orchestrator's providers/brain/exploration.
+
+        Deferred out of __init__ because it performs I/O (provider probing,
+        optional codebase exploration). Only the CLI-created default orchestrator
+        is initialized; an injected orchestrator is the caller's responsibility and
+        is left untouched (mirrors the injected conversation-store contract).
+        """
+        if not self._orchestrator_is_default:
+            return
+        self.orchestrator.initialize(
             auto_register=True,
             orchestrator_provider=self._brain,
             auto_explore=self._auto_explore,
-            show_provider_status=self._show_provider_status
+            show_provider_status=self._show_provider_status,
         )
-        return orch
 
     def _create_default_state_manager(self) -> PlanStateManager:
         """Create default state manager."""

--- a/src/scrappy/cli/textual/app.py
+++ b/src/scrappy/cli/textual/app.py
@@ -108,7 +108,15 @@ class ScrappyApp(App):
             interactive_mode: The InteractiveMode instance (immediate mode)
             output_adapter: The TextualOutputAdapter to consume messages from
             theme: Optional theme for consistent styling
-            cli_factory: Factory function to create CLI (deferred mode)
+            cli_factory: Factory function to create CLI (deferred mode). It is
+                called on a background thread and MUST return a CLI that the app
+                can wire directly into interactive mode. If the orchestrator needs
+                to be operational (a brain/provider configured), the factory must
+                return an INITIALIZED CLI -- call cli.initialize() before returning,
+                as the production factory create_cli_from_context does. CLI
+                construction is side effect free since the ctor I/O deferral, so a
+                bare CLI() yields an UNINITIALIZED orchestrator (no brain); that is
+                fine only for tests that never exercise the orchestrator.
             clipboard: Clipboard service for OS clipboard integration
             mouse_policy: Terminal mouse reporting policy
             now: Monotonic-ish clock for double-tap timing (injectable for

--- a/tests/cli/test_cli_init_no_io.py
+++ b/tests/cli/test_cli_init_no_io.py
@@ -16,6 +16,7 @@ from unittest.mock import MagicMock, patch
 
 from scrappy.cli.command_history import get_default_history_path
 from scrappy.cli.core import CLI
+from scrappy.orchestrator import AgentOrchestrator
 from scrappy.infrastructure.persistence import ConversationStoreProtocol
 
 
@@ -87,6 +88,65 @@ def test_initialize_creates_default_store_and_loads_history():
                         ]
                         # Command history rebuilt against the real default path.
                         mock_cmd_history.assert_any_call(history_file=get_default_history_path())
+
+
+def test_init_does_not_initialize_default_orchestrator():
+    """PR-B: constructing the CLI builds the default orchestrator object but must
+    not call its initialize() (provider probing / brain setup / exploration). That
+    side-effectful setup is deferred to CLI.initialize()."""
+    fake_orch = MagicMock()
+    with patch("scrappy.cli.core.AgentOrchestrator", return_value=fake_orch):
+        with patch.object(CLI, "_create_default_io", return_value=MagicMock()):
+            with patch("scrappy.cli.core.initialize_cli_handlers", return_value=_mock_handlers()):
+                with patch("scrappy.cli.core.create_conversation_store"):
+                    with patch("scrappy.cli.core.CommandHistory"):
+                        cli = CLI()
+
+                        assert cli.orchestrator is fake_orch
+                        fake_orch.initialize.assert_not_called()
+
+
+def test_initialize_initializes_default_orchestrator_with_config():
+    """PR-B: CLI.initialize() must initialize the default orchestrator exactly once,
+    forwarding the construction-time config (brain, auto_explore, provider status)."""
+    fake_orch = MagicMock()
+    with patch("scrappy.cli.core.AgentOrchestrator", return_value=fake_orch):
+        with patch.object(CLI, "_create_default_io", return_value=MagicMock()):
+            with patch("scrappy.cli.core.initialize_cli_handlers", return_value=_mock_handlers()):
+                with patch("scrappy.cli.core.create_conversation_store", return_value=None):
+                    with patch("scrappy.cli.core.CommandHistory"):
+                        cli = CLI(
+                            brain="myprov",
+                            auto_explore=True,
+                            show_provider_status=True,
+                        )
+                        fake_orch.initialize.assert_not_called()
+
+                        cli.initialize(offer_session_restore=False)
+
+                        fake_orch.initialize.assert_called_once_with(
+                            auto_register=True,
+                            orchestrator_provider="myprov",
+                            auto_explore=True,
+                            show_provider_status=True,
+                        )
+
+
+def test_injected_orchestrator_is_never_initialized_by_cli():
+    """PR-B: an injected orchestrator is the caller's responsibility. The CLI must
+    not call initialize() on it in __init__ or in CLI.initialize() (mirrors the
+    injected-store contract)."""
+    injected = MagicMock(spec=AgentOrchestrator)
+    with patch.object(CLI, "_create_default_io", return_value=MagicMock()):
+        with patch("scrappy.cli.core.initialize_cli_handlers", return_value=_mock_handlers()):
+            with patch("scrappy.cli.core.create_conversation_store", return_value=None):
+                with patch("scrappy.cli.core.CommandHistory"):
+                    cli = CLI(orchestrator=injected)
+                    injected.initialize.assert_not_called()
+
+                    cli.initialize(offer_session_restore=False)
+
+                    injected.initialize.assert_not_called()
 
 
 def test_injected_store_is_never_replaced_by_default():

--- a/tests/cli/textual/test_metrics_status_pilot.py
+++ b/tests/cli/textual/test_metrics_status_pilot.py
@@ -21,8 +21,16 @@ from scrappy.cli.screens.chat_surface import ChatSurface
 
 
 def create_test_app() -> ScrappyApp:
-    """Create a ScrappyApp instance with a real CLI in mock mode."""
-    return ScrappyApp(cli_factory=lambda: CLI())
+    """Create a ScrappyApp instance with a real, initialized CLI in mock mode.
+
+    The factory returns an INITIALIZED CLI. Since CLI construction was made side
+    effect free, the default orchestrator's brain/provider setup happens in
+    CLI.initialize(), not in the constructor. A bare CLI() would hand the app an
+    orchestrator with no mock brain configured, so the metrics line would stay
+    stuck at "provider: --". Production factories (create_cli_from_context) call
+    initialize() for exactly this reason.
+    """
+    return ScrappyApp(cli_factory=lambda: CLI().initialize(offer_session_restore=False))
 
 
 class TestMetricsStatusPilot:


### PR DESCRIPTION
CLI.__init__ now builds the default AgentOrchestrator as a bare object but no longer calls orch.initialize() (provider probing, brain setup, optional codebase exploration). That setup moves to CLI._initialize_orchestrator(), invoked from CLI.initialize(), so construction is genuinely side-effect free.

Only the CLI-created default orchestrator is initialized; an injected orchestrator is the caller's responsibility and is left untouched, mirroring the injected conversation-store contract. Production paths (create_cli / create_cli_from_context) already call cli.initialize() immediately after construction, so behavior there is unchanged.

Completes the side-effect-free constructor goal started in PR-A; the __init__ docstring no longer carries the "not yet fully side effect free" caveat.

Adds three behavior tests pinning the contract: __init__ does not initialize the default orchestrator, initialize() does (forwarding brain/auto_explore/ status config), and an injected orchestrator is never initialized by the CLI.

Tracked: scrappy-y3vf

## Description

Brief description of the changes in this PR.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have run `pytest tests/` and all tests pass

## Coverage

Current test run: `python -m pytest tests/ --cov=src --cov-report=term-missing`

Does this PR maintain or improve coverage? [ ] Yes / [ ] No

## Related Issues

Closes #(issue number)
