### PR TITLE
Fix mock-mode metrics: register mock model in selector (scrappy-h4q9)

### DIFF
--- a/src/scrappy/orchestrator/factory.py
+++ b/src/scrappy/orchestrator/factory.py
@@ -404,7 +404,18 @@ class OrchestratorFactory:
 
         Determines which models have API keys configured and creates
         a selector that provides deterministic, priority-based selection.
+
+        Mock Mode:
+        If SCRAPPY_MOCK_LLM is set, returns MockModelSelectionService so a mock
+        model is always selectable. Without it, mock mode has no API keys, the
+        selector is empty, and selection raises before MockLLMService runs,
+        leaving metrics stuck at provider=None.
         """
+        from .mock_llm_service import is_mock_mode_enabled, MockModelSelectionService
+        if is_mock_mode_enabled():
+            logger.info("Mock model selector enabled via SCRAPPY_MOCK_LLM env var")
+            return MockModelSelectionService()
+
         api_key_service = create_api_key_service()
         configured_models = self._get_configured_models(api_key_service)
         return ModelSelectionService(configured_models=configured_models)

--- a/src/scrappy/orchestrator/mock_llm_service.py
+++ b/src/scrappy/orchestrator/mock_llm_service.py
@@ -17,7 +17,9 @@ import time
 from datetime import datetime
 from typing import Any, Iterator, Optional, AsyncIterator
 
+from scrappy.infrastructure.exceptions.failure_kinds import FailureKind
 from scrappy.orchestrator.types import StreamChunk
+from .model_selection import ModelSelectionType
 from .provider_types import LLMResponse
 
 
@@ -336,6 +338,64 @@ class MockLLMService:
         """Reset call tracking."""
         self._call_count = 0
         self._calls.clear()
+
+
+class MockModelSelectionService:
+    """
+    Model selection service for mock mode (implements ModelSelectionServiceProtocol).
+
+    In mock mode there are no API keys, so the real selector is built with an
+    empty configured set. The orchestrator's normal selection path then returns
+    no model: _select_initial_model returns None and
+    stream_completion_with_fallback raises "No model available" BEFORE
+    MockLLMService ever runs. The metrics path consequently posts provider=None
+    and the TUI status line stays stuck at "provider: --".
+
+    This service makes a single mock model always selectable for every selection
+    type and any context requirement, so streaming reaches MockLLMService and the
+    resulting chunks carry provider="mock" through the same path real providers
+    use. The mock model is never unhealthy and is treated as having unlimited
+    context.
+    """
+
+    MOCK_MODEL_ID = "mock/mock-model"
+
+    def select(
+        self,
+        selection_type: ModelSelectionType,
+        min_context: int = 0,
+        session_preferred: Optional[str] = None,
+        exclude: Optional[set[str]] = None,
+    ) -> str:
+        """Always return the mock model, honoring session stickiness trivially."""
+        if session_preferred == self.MOCK_MODEL_ID:
+            return session_preferred
+        return self.MOCK_MODEL_ID
+
+    def get_models_for_type(self, selection_type: ModelSelectionType) -> list[str]:
+        """The mock model is configured for every selection type."""
+        return [self.MOCK_MODEL_ID]
+
+    def mark_unhealthy(
+        self,
+        model: str,
+        kind: FailureKind,
+        retry_after: Optional[float] = None,
+    ) -> None:
+        """No-op: the mock model never becomes unhealthy."""
+        return None
+
+    def update_configured(self, new_set: set[str]) -> None:
+        """No-op: the mock configured set is fixed."""
+        return None
+
+    def clear_failure_kinds(self, kinds: set[FailureKind]) -> None:
+        """No-op: the mock model has no tracked health state to clear."""
+        return None
+
+    def is_available(self, model_id: str) -> bool:
+        """The mock model is always available; nothing else is configured."""
+        return model_id == self.MOCK_MODEL_ID
 
 
 def is_mock_mode_enabled() -> bool:

--- a/tests/orchestrator/test_mock_mode_selection.py
+++ b/tests/orchestrator/test_mock_mode_selection.py
@@ -1,0 +1,111 @@
+"""
+Behavior tests for mock-mode model selection (scrappy-h4q9).
+
+Regression: in mock mode the factory swapped in MockLLMService but built the
+model selector with an empty configured set (no API keys). The orchestrator's
+normal selection path then returned no model, so
+stream_completion_with_fallback raised "No model available" before the mock
+service ran. Metrics consequently posted provider=None and the TUI status line
+stuck at "provider: --".
+
+These tests prove that mock mode now resolves a selectable model for every
+selection type and that streaming reaches MockLLMService, emitting chunks with
+provider="mock" (the value the metrics path turns into the "mock:" display).
+"""
+
+import pytest
+
+from scrappy.orchestrator.core import create_orchestrator
+from scrappy.orchestrator.mock_llm_service import (
+    MockLLMService,
+    MockModelSelectionService,
+)
+from scrappy.orchestrator.model_selection import ModelSelectionType
+
+
+class TestMockModelSelectionService:
+    """The mock selector honors the selection contract for every type."""
+
+    def test_selects_a_model_for_every_selection_type(self):
+        service = MockModelSelectionService()
+
+        for selection_type in ModelSelectionType:
+            selected = service.select(selection_type)
+            assert selected
+            assert selected in service.get_models_for_type(selection_type)
+            assert service.is_available(selected)
+
+    def test_satisfies_large_min_context(self):
+        """CHAT requests a 32k min context; the mock model must still resolve."""
+        service = MockModelSelectionService()
+
+        selected = service.select(ModelSelectionType.CHAT, min_context=32768)
+
+        assert selected == MockModelSelectionService.MOCK_MODEL_ID
+
+    def test_honors_session_preference_for_mock_model(self):
+        service = MockModelSelectionService()
+        mock_model = MockModelSelectionService.MOCK_MODEL_ID
+
+        result = service.select(
+            ModelSelectionType.INSTRUCT,
+            session_preferred=mock_model,
+        )
+
+        assert result == mock_model
+
+    def test_unconfigured_model_is_not_available(self):
+        service = MockModelSelectionService()
+
+        assert service.is_available("groq/llama-3.1-8b-instant") is False
+
+
+@pytest.fixture
+def mock_mode(monkeypatch):
+    """Enable deterministic, latency-free mock mode for the orchestrator."""
+    monkeypatch.setenv("SCRAPPY_MOCK_LLM", "1")
+    monkeypatch.setenv("SCRAPPY_MOCK_LATENCY_MS", "0")
+    monkeypatch.setenv("SCRAPPY_MOCK_RESPONSE", "Mock response")
+
+
+class TestMockModeStreaming:
+    """End-to-end: mock-mode streaming emits mock-provider chunks, not errors."""
+
+    def test_orchestrator_uses_mock_services_in_mock_mode(self, mock_mode):
+        orch = create_orchestrator()
+
+        assert isinstance(orch.llm_service, MockLLMService)
+        assert isinstance(orch.model_selector, MockModelSelectionService)
+
+    def test_instruct_streaming_emits_mock_provider(self, mock_mode):
+        """The failing path: INSTRUCT streaming must not raise and must carry
+        provider='mock' so metrics show 'mock:' instead of 'provider: --'."""
+        orch = create_orchestrator()
+
+        chunks = list(
+            orch.stream_completion_with_fallback(
+                messages=[{"role": "user", "content": "hi"}],
+                selection_type=ModelSelectionType.INSTRUCT,
+            )
+        )
+
+        assert chunks, "expected at least one stream chunk"
+        assert all(chunk.provider == "mock" for chunk in chunks)
+        assert "".join(chunk.content or "" for chunk in chunks) == "Mock response"
+
+    @pytest.mark.parametrize(
+        "selection_type",
+        [ModelSelectionType.FAST, ModelSelectionType.CHAT],
+    )
+    def test_other_selection_types_do_not_raise(self, mock_mode, selection_type):
+        """delegate() reaches FAST/CHAT in mock mode; neither may raise."""
+        orch = create_orchestrator()
+
+        chunks = list(
+            orch.stream_completion_with_fallback(
+                messages=[{"role": "user", "content": "hi"}],
+                selection_type=selection_type,
+            )
+        )
+
+        assert all(chunk.provider == "mock" for chunk in chunks)


### PR DESCRIPTION
In mock mode the factory swapped in MockLLMService but built the model selector with an empty configured set (no API keys). The orchestrator's normal selection path then returned no model: _select_initial_model returned None and stream_completion_with_fallback raised "No model available" before MockLLMService ever ran. Metrics posted provider=None and the TUI status line stuck at "provider: --".

Option 2 (selection stays a pure wiring concern, core untouched): add MockModelSelectionService implementing ModelSelectionServiceProtocol and return it from OrchestratorFactory.create_model_selector when SCRAPPY_MOCK_LLM is set, mirroring the existing create_llm_service mock gate. A single mock model is always selectable for every selection type and any min_context, so streaming reaches MockLLMService and chunks carry provider="mock" through the same path real providers use.

Tests: orchestrator-level streaming now emits provider="mock" for INSTRUCT/FAST/CHAT instead of raising, plus a selector-contract test. The CI-excluded TUI test test_metrics_status_updates_after_message flips from "provider: --" to passing.

## Description

Brief description of the changes in this PR.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have run `pytest tests/` and all tests pass

## Coverage

Current test run: `python -m pytest tests/ --cov=src --cov-report=term-missing`

Does this PR maintain or improve coverage? [ ] Yes / [ ] No

## Related Issues

Closes #(issue number)
