### PR TITLE
Zero the mypy singleton/annotation errors (scrappy-21x0 PR-M1)

### DIFF
--- a/src/scrappy/cli/codebase.py
+++ b/src/scrappy/cli/codebase.py
@@ -202,7 +202,7 @@ class CLICodebaseAnalysis:
             dict: Mapping of category names to lists of relative file paths.
                 Categories include: python, javascript, config, docs, other.
         """
-        files = {k: [] for k in EXTENSIONS_BY_CATEGORY}
+        files: dict[str, list[str]] = {k: [] for k in EXTENSIONS_BY_CATEGORY}
 
         for root, dirs, filenames in os.walk(path):
             # Skip common non-source directories

--- a/src/scrappy/context/file_scanner.py
+++ b/src/scrappy/context/file_scanner.py
@@ -54,7 +54,7 @@ class FileScanner:
             skip_dirs = get_paths_config()
 
         # Initialize result with all categories
-        files = {k: [] for k in extensions_by_category}
+        files: dict[str, list[str]] = {k: [] for k in extensions_by_category}
 
         # Handle nonexistent path
         if not project_path.exists():

--- a/src/scrappy/context/semantic/state.py
+++ b/src/scrappy/context/semantic/state.py
@@ -17,7 +17,7 @@ except ImportError:
     lancedb = None
     LanceModel = object
 
-    def Field(**kwargs):  # noqa: N802 - matching pydantic's Field API
+    def Field(**kwargs):  # type: ignore[no-redef]  # noqa: N802 - runtime fallback matching pydantic's Field API
         return None
 
 from ..protocols import IndexState

--- a/src/scrappy/infrastructure/config/loader.py
+++ b/src/scrappy/infrastructure/config/loader.py
@@ -224,21 +224,10 @@ class ConfigLoader:
             Configuration dictionary
 
         Raises:
-            ImportError: If tomli/tomllib is not available
             ValueError: If TOML is invalid
         """
-        try:
-            # Python 3.11+ has tomllib in stdlib
-            import tomllib
-        except ImportError:
-            try:
-                # Fallback to tomli for older Python versions
-                import tomli as tomllib
-            except ImportError:
-                raise ImportError(
-                    "tomli is required to load TOML configuration files on Python < 3.11.\n"
-                    "Install it with: pip install tomli"
-                )
+        # tomllib is stdlib on the supported floor (requires-python >= 3.11)
+        import tomllib
 
         try:
             with open(path, 'rb') as f:

--- a/src/scrappy/infrastructure/file_system.py
+++ b/src/scrappy/infrastructure/file_system.py
@@ -167,7 +167,7 @@ class InMemoryFileSystem:
             normalized = normalized.rstrip("/")
 
         # Resolve . and .. components
-        parts = []
+        parts: list[str] = []
         for part in normalized.split("/"):
             if part == "." or part == "":
                 continue

--- a/src/scrappy/orchestrator/context_coordinator.py
+++ b/src/scrappy/orchestrator/context_coordinator.py
@@ -7,10 +7,7 @@ like logging and task execution.
 
 from typing import Dict, Any, Optional, Callable
 
-try:
-    from ..context.protocols import CodebaseContextProtocol
-except ImportError:
-    from context.protocols import CodebaseContextProtocol
+from ..context.protocols import CodebaseContextProtocol
 
 from .output import BaseOutputProtocol, ConsoleOutput
 

--- a/src/scrappy/orchestrator/memory.py
+++ b/src/scrappy/orchestrator/memory.py
@@ -5,6 +5,7 @@ Provides ephemeral storage for file reads, searches, and discoveries during a se
 """
 
 from datetime import datetime
+from typing import Any
 
 
 class WorkingMemory:
@@ -186,7 +187,7 @@ class WorkingMemory:
         Returns:
             Dict with all memory data (timestamps as ISO strings)
         """
-        data = {
+        data: dict[str, Any] = {
             'file_reads': {},
             'search_results': [],
             'git_operations': [],

--- a/src/scrappy/orchestrator/rate_limiting/factory.py
+++ b/src/scrappy/orchestrator/rate_limiting/factory.py
@@ -133,7 +133,7 @@ def create_rate_limit_components(
         storage=storage,
         policy=policy,
         calculator=calculator,
-        recommender=None,  # type: ignore - will be set next
+        recommender=None,  # type: ignore[arg-type]  # circular wiring: recommender is set right after creation
         auto_load=False,  # Load after all wiring is complete
         config=config,
     )

--- a/src/scrappy/orchestrator/rate_limiting/tracker.py
+++ b/src/scrappy/orchestrator/rate_limiting/tracker.py
@@ -213,7 +213,7 @@ class RateLimitTracker:
 
         # Get our tracked usage for fields headers don't provide
         usage = self._usage.get("providers", {}).get(provider, {})
-        first_model = next(iter(usage.values()), {}) if usage else {}
+        first_model: Dict[str, Any] = next(iter(usage.values()), {}) if usage else {}
 
         return {
             "requests_remaining_today": requests_remaining,

--- a/src/scrappy/orchestrator/usage_reporter.py
+++ b/src/scrappy/orchestrator/usage_reporter.py
@@ -12,10 +12,7 @@ from datetime import datetime
 from typing import Optional, Dict, Any, List
 import json
 
-try:
-    from .protocols import CacheProtocol
-except ImportError:
-    from orchestrator.protocols import CacheProtocol
+from .protocols import CacheProtocol
 
 
 class UsageReporter:


### PR DESCRIPTION
Kills 15 of the 399 baseline errors (399 -> 384), zero new errors:
- var-annotated x5: annotate empty-container bindings in cli/codebase.py, context/file_scanner.py, infrastructure/file_system.py, orchestrator/memory.py, orchestrator/rate_limiting/tracker.py.
- no-redef x4: delete the dead tomli fallback in infrastructure/config/loader.py (requires-python >= 3.11 makes stdlib tomllib unconditional); narrow reasoned ignore on the genuine runtime Field shim in context/semantic/state.py; delete dead absolute-import fallbacks in orchestrator/usage_reporter.py and orchestrator/context_coordinator.py (nothing imports these modules as top-level; the sys.path helpers that could enable it have no callers).
- syntax x1: fix the malformed type-ignore in orchestrator/rate_limiting/ factory.py to a scoped ignore[arg-type], which also absorbs that line's arg-type error as anticipated.
- Bonus cascade in memory.py: 3 attr-defined + 1 index error existed only because the un-annotated dict made mypy infer Collection[Any]; the annotation removes them with no further edits.

Four-check verification: mypy set-diff vs the 399 reference = 15 removals, 0 additions; import walk 293 modules 0 failures; collect-only 5098 unchanged; ruff gate clean; focused tests for all touched modules 313 passed; default suite 4989 passed, 2 skipped, 1 pre-existing flake (verified identical on unmodified main).

No protocol edits, no Optional lifecycle changes; func-returns-value x2 in context_coordinator.py deliberately left for PR-M4 (CodebaseContextProtocol explore() drift).