### PR TITLE
Add theme to the CLI IO contract (scrappy-21x0 PR-M2)

### DIFF
--- a/src/scrappy/cli/io_interface.py
+++ b/src/scrappy/cli/io_interface.py
@@ -15,6 +15,8 @@ Usage:
 
 from typing import Optional, List, Dict, Any
 
+from ..infrastructure.theme import ThemeProtocol, DEFAULT_THEME
+
 # Re-export the protocol from cli protocols (canonical location); many modules
 # import CLIIOProtocol from this module. The redundant alias marks the re-export
 # as intentional so lint does not strip it.
@@ -43,13 +45,15 @@ class TestIO:
     def __init__(
         self,
         inputs: Optional[List[str]] = None,
-        confirmations: Optional[List[bool]] = None
+        confirmations: Optional[List[bool]] = None,
+        theme: Optional[ThemeProtocol] = None
     ):
         """Initialize TestIO with preset inputs and confirmations.
 
         Args:
             inputs: List of input strings to return from prompt/input_line
             confirmations: List of boolean values to return from confirm
+            theme: Optional theme for styling. Defaults to DEFAULT_THEME.
         """
         self._inputs: List[str] = list(inputs) if inputs else []
         self._confirmations: List[bool] = list(confirmations) if confirmations else []
@@ -57,6 +61,9 @@ class TestIO:
         self._styled_outputs: List[Dict[str, Any]] = []
         self._input_index = 0
         self._confirm_index = 0
+        # Plain attribute (not a property) so tests can swap themes freely;
+        # an attribute satisfies the protocol's read-only theme property.
+        self.theme: ThemeProtocol = theme or DEFAULT_THEME
 
     def echo(self, message: str = "", nl: bool = True) -> None:
         """Capture output to internal buffer."""

--- a/src/scrappy/cli/protocols.py
+++ b/src/scrappy/cli/protocols.py
@@ -17,6 +17,7 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import TYPE_CHECKING, Protocol, Dict, Any, List, Optional, Callable, runtime_checkable, Generator
 from contextlib import contextmanager
+from ..infrastructure.theme import ThemeProtocol
 from ..orchestrator.protocols import Orchestrator
 
 if TYPE_CHECKING:
@@ -179,6 +180,11 @@ class CLIIOProtocol(Protocol):
         border_style: str = "blue"
     ) -> None:
         """Display content in a panel with optional title."""
+        ...
+
+    @property
+    def theme(self) -> ThemeProtocol:
+        """Current theme used for styled output."""
         ...
 
 


### PR DESCRIPTION
theme was accessed 88 times across 15 modules on values typed CLIIOProtocol, but existed only on the UnifiedIO implementation: a de facto contract member missing from the protocol. Add it to CLIIOProtocol as a read-only ThemeProtocol property (chosen over a separate ThemedIOProtocol because nearly every CLIIOProtocol consumer uses it; ISP split would serve no real client) and bring TestIO into conformance with a settable theme attribute defaulting to DEFAULT_THEME (plain attribute, not property: tests swap themes on instances, and an attribute satisfies the protocol's read-only property structurally). MockIO in tests/helpers.py already mocked theme.

Kills 88 of the 384 baseline errors (384 -> 296), zero new errors, all 88 removals are the theme attr-defined lines.

Four-check verification: set-diff vs post-M1 reference = 88 removals 0 additions; import walk 293 modules 0 failures; collect-only 5098 unchanged; ruff gate clean; focused IO/theme tests 121 passed + test_command_router 48 passed; default suite 4989 passed, 2 skipped, 1 pre-existing flake.

First cut used a read-only property on TestIO and broke 58 tests that assign io.theme; caught by the suite gate, fixed before commit. Discovered en route: pytest.ini duels with pyproject pytest config (scrappy-larp).