### PR TITLE
Reconcile orchestrator manager protocols with implementations

### DIFF
--- a/src/scrappy/orchestrator/manager_protocols.py
+++ b/src/scrappy/orchestrator/manager_protocols.py
@@ -7,6 +7,12 @@ specific concerns like delegation, task execution, background tasks, and reporti
 
 from typing import AsyncIterator, Protocol, Dict, Any, List, Optional, Coroutine, runtime_checkable
 
+from .constants import (
+    DEFAULT_MAX_CONCURRENT,
+    DEFAULT_MAX_TOKENS,
+    DEFAULT_PROVIDER,
+    DEFAULT_TEMPERATURE,
+)
 from .provider_types import LLMResponse
 from .types import StreamChunk
 from ..context import CodebaseContextProtocol
@@ -165,6 +171,77 @@ class DelegationManagerProtocol(Protocol):
         """
         ...
 
+    def delegate_batch(
+        self,
+        tasks: list[dict],
+        provider_name: str = DEFAULT_PROVIDER,
+        **kwargs: Any,
+    ) -> list[LLMResponse]:
+        """
+        Process multiple tasks with same provider (synchronous).
+
+        Args:
+            tasks: List of task dicts with 'prompt' and optional 'system_prompt', 'kwargs'
+            provider_name: Provider to use for all tasks
+            **kwargs: Additional arguments passed to delegate
+
+        Returns:
+            List of LLMResponse objects in the same order as input tasks
+        """
+        ...
+
+    async def batch_delegate_async(
+        self,
+        tasks: list[dict],
+        provider_name: str = DEFAULT_PROVIDER,
+        max_concurrent: int = DEFAULT_MAX_CONCURRENT,
+        **kwargs: Any,
+    ) -> list[LLMResponse]:
+        """
+        Process multiple tasks in parallel using async.
+
+        Args:
+            tasks: List of task dicts with 'prompt' and optional 'system_prompt', 'kwargs'
+            provider_name: Provider to use for all tasks
+            max_concurrent: Maximum number of concurrent requests
+            **kwargs: Additional arguments passed to all tasks
+
+        Returns:
+            List of LLMResponse objects in the same order as input tasks
+        """
+        ...
+
+    async def multi_provider_query_async(
+        self,
+        prompt: str,
+        providers: list[str],
+        model: Optional[str] = None,
+        system_prompt: Optional[str] = None,
+        max_tokens: int = DEFAULT_MAX_TOKENS,
+        temperature: float = DEFAULT_TEMPERATURE,
+        **kwargs: Any,
+    ) -> dict[str, tuple]:
+        """
+        Query multiple providers in parallel for the same prompt.
+
+        Args:
+            prompt: The prompt to send to all providers
+            providers: List of provider names to query
+            model: Specific model (optional)
+            system_prompt: System prompt (optional)
+            max_tokens: Maximum tokens in response
+            temperature: Sampling temperature
+            **kwargs: Additional arguments passed to requests
+
+        Returns:
+            Dict mapping provider name to (LLMResponse, task_record) tuple.
+            Failed providers are excluded from results.
+
+        Raises:
+            ValueError: If providers list is empty
+        """
+        ...
+
 
 @runtime_checkable
 class TaskExecutorProtocol(Protocol):
@@ -217,6 +294,63 @@ class TaskExecutorProtocol(Protocol):
 
         Returns:
             List of task results in same order
+        """
+        ...
+
+    def plan(
+        self,
+        task: str,
+        context: Optional[str] = None,
+        max_steps: int = 10,
+        complexity_score: Optional[int] = None,
+    ) -> list[dict]:
+        """
+        Break down a complex task into steps.
+
+        Args:
+            task: The complex task to plan
+            context: Optional context about the codebase/project
+            max_steps: Maximum number of steps to generate
+            complexity_score: Optional complexity score (1-10). If <= 3, planning is skipped.
+
+        Returns:
+            List of step dicts with 'step', 'description', 'provider_type' keys
+        """
+        ...
+
+    def reason(
+        self,
+        question: str,
+        context: Optional[str] = None,
+        evidence: Optional[list[str]] = None,
+    ) -> dict:
+        """
+        Perform complex reasoning on a question or problem.
+
+        Args:
+            question: The question or problem to reason about
+            context: Optional context information
+            evidence: Optional list of evidence/facts to consider
+
+        Returns:
+            Dict with 'question', 'analysis', 'conclusion', 'confidence' keys
+        """
+        ...
+
+    def synthesize(
+        self,
+        results: list[LLMResponse],
+        synthesis_prompt: str = "Synthesize these results into a coherent summary:",
+    ) -> str:
+        """
+        Synthesize multiple agent results into a coherent summary.
+
+        Args:
+            results: List of LLMResponse objects from various agents
+            synthesis_prompt: Prompt for how to synthesize
+
+        Returns:
+            Synthesized summary string
         """
         ...
 
@@ -385,6 +519,24 @@ class UsageReporterProtocol(Protocol):
         """
         ...
 
+    def get_usage_report(self) -> Dict[str, Any]:
+        """
+        Get usage report across all providers.
+
+        Returns:
+            Dictionary with per-provider usage statistics
+        """
+        ...
+
+    def get_cache_stats(self) -> Dict[str, Any]:
+        """
+        Get cache statistics.
+
+        Returns:
+            Dictionary with cache hit/miss statistics
+        """
+        ...
+
 
 @runtime_checkable
 class StatusReporterProtocol(Protocol):
@@ -434,6 +586,15 @@ class StatusReporterProtocol(Protocol):
 
         Returns:
             Dictionary mapping component names to health status
+        """
+        ...
+
+    def get_selection_info(self) -> dict:
+        """
+        Get model selection information.
+
+        Returns:
+            Dictionary describing current model selection state
         """
         ...
 

--- a/src/scrappy/orchestrator/protocols.py
+++ b/src/scrappy/orchestrator/protocols.py
@@ -12,10 +12,12 @@ This is the canonical location for all orchestrator-related protocols including:
 """
 
 from dataclasses import dataclass
+from datetime import datetime
 from typing import Protocol, Optional, Dict, Any, List, runtime_checkable, AsyncIterator, Iterator, Type, TypeVar
 
 from pydantic import BaseModel
 
+from .model_selection import ModelSelectionType
 from .provider_types import LLMResponse, LLMProviderBase, ProviderLimits
 from .types import StreamChunk
 
@@ -454,6 +456,71 @@ class RateLimitTrackerProtocol(Protocol):
         """
         ...
 
+    def is_rate_limited(self, provider_name: str, registry: Any) -> bool:
+        """
+        Check if provider is currently rate limited.
+
+        Args:
+            provider_name: Provider name
+            registry: Provider registry for limit lookup
+
+        Returns:
+            True if provider is rate limited, False otherwise
+        """
+        ...
+
+    def reset_rate_tracking(self, provider_name: Optional[str] = None) -> None:
+        """
+        Reset rate limit tracking.
+
+        Args:
+            provider_name: Provider to reset (None for all providers)
+        """
+        ...
+
+    def get_rate_limit_status_extended(self, registry: Any) -> dict[str, Any]:
+        """
+        Get extended rate limit status for all providers.
+
+        Args:
+            registry: Provider registry for limit lookup
+
+        Returns:
+            Dictionary mapping provider names to extended status info
+        """
+        ...
+
+    def check_all_warnings(self, registry: Any) -> List[str]:
+        """
+        Check all providers for rate limit warnings.
+
+        Args:
+            registry: Provider registry for limit lookup
+
+        Returns:
+            List of warning messages
+        """
+        ...
+
+    def get_remaining_quota_for_provider(
+        self,
+        provider_name: str,
+        registry: Any,
+        model: Optional[str] = None,
+    ) -> dict[str, Any]:
+        """
+        Get remaining quota for a provider.
+
+        Args:
+            provider_name: Provider name
+            registry: Provider registry for limit lookup
+            model: Specific model (optional)
+
+        Returns:
+            Dictionary with remaining quota details
+        """
+        ...
+
 
 @runtime_checkable
 class SessionManagerProtocol(Protocol):
@@ -537,6 +604,36 @@ class SessionManagerProtocol(Protocol):
         """
         ...
 
+    def save_session(
+        self,
+        working_memory: "WorkingMemoryProtocol",
+        task_history: list,
+        session_start: datetime,
+        conversation_history: Optional[list] = None,
+    ) -> str:
+        """
+        Save current session to disk.
+
+        Args:
+            working_memory: Working memory to persist
+            task_history: Task history entries
+            session_start: When the session started
+            conversation_history: Optional conversation history entries
+
+        Returns:
+            Path or identifier of the saved session
+        """
+        ...
+
+    def load_session(self) -> dict:
+        """
+        Load previous session from disk.
+
+        Returns:
+            Dictionary with 'status' and restored session state
+        """
+        ...
+
 
 @runtime_checkable
 class ProviderSelectorProtocol(Protocol):
@@ -607,6 +704,42 @@ class ProviderSelectorProtocol(Protocol):
         Args:
             provider: Provider name
             duration_seconds: How long to mark unavailable
+        """
+        ...
+
+    def setup_brain(self, preferred_provider: Optional[str] = None) -> tuple[str, None]:
+        """
+        Set up the brain provider for orchestration.
+
+        Args:
+            preferred_provider: Preferred provider name (used if available)
+
+        Returns:
+            Tuple of (provider name, None placeholder)
+        """
+        ...
+
+    def get_model(self, selection_type: ModelSelectionType) -> tuple[str, None]:
+        """
+        Get provider for a model selection type.
+
+        Args:
+            selection_type: Model selection type (fast, balanced, etc.)
+
+        Returns:
+            Tuple of (provider name, None placeholder)
+        """
+        ...
+
+    def recommend(self, requirements: dict) -> str:
+        """
+        Recommend a provider for the given requirements.
+
+        Args:
+            requirements: Requirement hints (task type, context size, etc.)
+
+        Returns:
+            Recommended provider name
         """
         ...
 
@@ -691,6 +824,24 @@ class ProviderRegistryProtocol(Protocol):
     def clear(self) -> None:
         """
         Clear all registered providers.
+        """
+        ...
+
+    def list_available(self) -> list[str]:
+        """
+        List names of providers that are currently available.
+
+        Returns:
+            List of available provider names
+        """
+        ...
+
+    def get_provider_info(self) -> dict[str, dict]:
+        """
+        Get detailed information for all registered providers.
+
+        Returns:
+            Dictionary mapping provider names to info dictionaries
         """
         ...
 


### PR DESCRIPTION
Reconcile orchestrator manager protocols with implementations (mypy M3a, scrappy-21x0)

Adds the 21 members that core.py calls and the concrete managers already implement to their 8 protocols (orchestrator/protocols.py and orchestrator/manager_protocols.py only). Signatures copied from the implementations. No implementation file touched, no behavior changes, no Any widening.

Set-diff contract (vs .docs/mypy-baseline-21x0-postM2.txt, line numbers stripped):
- Removed: exactly the 23 protocol-side union-attr errors in core.py.
- Added: exactly 2 newly exposed lifecycle/nullability errors. mypy stops checking a call once the union-attr error fires; making the protocols honest unmasked (1) the save_session working_memory argument being WorkingMemoryProtocol | None, and (2) the _brain_name inferred-None assignment. Both are already assigned to M3b (working_memory narrowing, _brain_name: Optional[str]).
- Net: 296 -> 275.

Verification: ruff src/ tests/ clean; import walk 293 modules, 0 failures; collect-only 5098; full default suite 4989 passed / 2 skipped with only the known pre-existing flake (test_create_undo_point_subprocess_isolation).