### PR TITLE
Narrow orchestrator component lifecycle types

### DIFF
--- a/src/scrappy/orchestrator/core.py
+++ b/src/scrappy/orchestrator/core.py
@@ -10,7 +10,7 @@ from typing import Awaitable, Callable, Optional, Iterator, AsyncIterator, TypeV
 from datetime import datetime
 from uuid import uuid4
 
-from .provider_types import ProviderRegistry, LLMResponse
+from .provider_types import ProviderRegistry, LLMResponse, LLMProviderBase
 from ..infrastructure.exceptions import (
     ProviderNotFoundError,
     FailureKind,
@@ -127,8 +127,8 @@ class AgentOrchestrator:
         # Core state
         self.task_history: list[dict] = []
         self.created_at = datetime.now()
-        self._brain = None
-        self._brain_name = None
+        self._brain: Optional[LLMProviderBase] = None
+        self._brain_name: Optional[str] = None
         self.context_aware = context_aware
         self.caching_enabled = enable_cache
         self.verbose_selection = verbose_selection
@@ -143,12 +143,15 @@ class AgentOrchestrator:
         self._fallback_preferred_models: dict[ModelSelectionType, str] = {}
         self._preferred_models_lock = threading.Lock()
 
-        # Use injected components or create defaults via factory
-        if all([
-            output, registry, cache, rate_tracker, working_memory,
-            session_manager, provider_selector, usage_reporter, status_reporter,
-            task_executor, context_manager, delegation_manager, background_manager
-        ]):
+        # Use injected components or create defaults via factory.
+        # Explicit truthiness chain (identical semantics to all([...]))
+        # so mypy narrows each component to non-None in this branch.
+        if (
+            output and registry and cache and rate_tracker and working_memory
+            and session_manager and provider_selector and usage_reporter
+            and status_reporter and task_executor and context_manager
+            and delegation_manager and background_manager
+        ):
             # All components provided - use them directly
             self.output = output
             self.registry = registry
@@ -990,7 +993,7 @@ class AgentOrchestrator:
 
     # Session Management (delegates to SessionManager)
 
-    def save_session(self, conversation_history: list = None) -> str:
+    def save_session(self, conversation_history: Optional[list] = None) -> str:
         """Save current session to disk."""
         return self.session_manager.save_session(
             self.working_memory,

--- a/src/scrappy/orchestrator/factory.py
+++ b/src/scrappy/orchestrator/factory.py
@@ -78,26 +78,48 @@ class OrchestratorComponents:
 
     Holds all created components to avoid parameter explosion.
     Uses protocol type hints following Dependency Inversion Principle.
+
+    Fields are non-Optional: create_all_components always populates every
+    component, and this container exists to carry that fully-built set.
     """
 
-    def __init__(self):
-        self.output: Optional[BaseOutputProtocol] = None
-        self.registry: Optional[ProviderRegistryProtocol] = None
-        self.background_manager: Optional[BackgroundTaskManagerProtocol] = None
-        self.codebase_context: Optional[ContextProvider] = None
-        self.cache: Optional[CacheProtocol] = None
-        self.rate_tracker: Optional[RateLimitTrackerProtocol] = None
-        self.working_memory: Optional[WorkingMemoryProtocol] = None
-        self.session_manager: Optional[SessionManagerProtocol] = None
-        self.provider_selector: Optional[ProviderSelectorProtocol] = None
-        self.usage_reporter: Optional[UsageReporterProtocol] = None
-        self.status_reporter: Optional[StatusReporterProtocol] = None
-        self.task_executor: Optional[TaskExecutorProtocol] = None
-        self.context_manager: Optional[ContextManagerProtocol] = None
-        self.delegation_manager: Optional[DelegationManagerProtocol] = None
-        self.llm_service: Optional[LLMServiceProtocol] = None
-        self.provider_status_tracker: Optional[ProviderStatusTrackerProtocol] = None
-        self.model_selector: Optional[ModelSelectionServiceProtocol] = None
+    def __init__(
+        self,
+        output: BaseOutputProtocol,
+        registry: ProviderRegistryProtocol,
+        background_manager: BackgroundTaskManagerProtocol,
+        codebase_context: ContextProvider,
+        cache: CacheProtocol,
+        rate_tracker: RateLimitTrackerProtocol,
+        working_memory: WorkingMemoryProtocol,
+        session_manager: SessionManagerProtocol,
+        provider_selector: ProviderSelectorProtocol,
+        usage_reporter: UsageReporterProtocol,
+        status_reporter: StatusReporterProtocol,
+        task_executor: TaskExecutorProtocol,
+        context_manager: ContextManagerProtocol,
+        delegation_manager: DelegationManagerProtocol,
+        llm_service: LLMServiceProtocol,
+        provider_status_tracker: ProviderStatusTrackerProtocol,
+        model_selector: ModelSelectionServiceProtocol,
+    ):
+        self.output = output
+        self.registry = registry
+        self.background_manager = background_manager
+        self.codebase_context = codebase_context
+        self.cache = cache
+        self.rate_tracker = rate_tracker
+        self.working_memory = working_memory
+        self.session_manager = session_manager
+        self.provider_selector = provider_selector
+        self.usage_reporter = usage_reporter
+        self.status_reporter = status_reporter
+        self.task_executor = task_executor
+        self.context_manager = context_manager
+        self.delegation_manager = delegation_manager
+        self.llm_service = llm_service
+        self.provider_status_tracker = provider_status_tracker
+        self.model_selector = model_selector
 
 
 class OrchestratorFactory:
@@ -166,81 +188,97 @@ class OrchestratorFactory:
         Returns:
             OrchestratorComponents with all components initialized
         """
-        components = OrchestratorComponents()
-
         # Core components (no dependencies)
-        components.output = self.create_output()
-        components.registry = self.create_registry()
-        components.background_manager = self.create_background_manager()
-        components.working_memory = self.create_working_memory()
+        output = self.create_output()
+        registry = self.create_registry()
+        background_manager = self.create_background_manager()
+        working_memory = self.create_working_memory()
 
         # Codebase context (needs project path)
-        components.codebase_context = self.create_codebase_context()
+        codebase_context = self.create_codebase_context()
 
         # Components that depend on codebase context
-        components.cache = self.create_cache(components.codebase_context)
-        components.rate_tracker = self.create_rate_tracker(components.codebase_context)
-        components.session_manager = self.create_session_manager(components.codebase_context)
+        cache = self.create_cache(codebase_context)
+        rate_tracker = self.create_rate_tracker(codebase_context)
+        session_manager = self.create_session_manager(codebase_context)
 
         # Provider selector (needs config)
-        components.provider_selector = self.create_provider_selector(
-            components.registry,
-            components.output,
+        provider_selector = self.create_provider_selector(
+            registry,
+            output,
             self.config
         )
 
         # Model selector (deterministic model selection)
-        components.model_selector = self.create_model_selector()
+        model_selector = self.create_model_selector()
 
         # Provider status tracker for LiteLLM callbacks
-        components.provider_status_tracker = self.create_provider_status_tracker()
+        provider_status_tracker = self.create_provider_status_tracker()
 
         # LLM Service (uses LiteLLM Router)
         # Always created - configures itself when API keys are available
-        components.llm_service = self.create_llm_service(
-            components.output,
-            components.rate_tracker,
-            components.provider_status_tracker
+        llm_service = self.create_llm_service(
+            output,
+            rate_tracker,
+            provider_status_tracker
         )
 
         # Usage reporter
-        components.usage_reporter = self.create_usage_reporter(components.cache)
+        usage_reporter = self.create_usage_reporter(cache)
 
         # Task executor (needs llm_service for LLM calls)
-        components.task_executor = self.create_task_executor(
-            components.llm_service,
+        task_executor = self.create_task_executor(
+            llm_service,
             task_history_recorder
         )
 
         # Context manager (needs task executor for summary generation)
-        components.context_manager = self.create_context_manager(
-            components.codebase_context,
-            components.output,
-            components.task_executor
+        context_manager = self.create_context_manager(
+            codebase_context,
+            output,
+            task_executor
         )
 
         # Delegation manager (needs many dependencies)
         # Always created - llm_service handles NotConfiguredError if no keys
-        components.delegation_manager = self.create_delegation_manager(
-            components.llm_service,
-            components.cache,
-            components.output,
-            components.working_memory,
-            components.context_manager,
-            components.rate_tracker,
-            components.registry,
+        delegation_manager = self.create_delegation_manager(
+            llm_service,
+            cache,
+            output,
+            working_memory,
+            context_manager,
+            rate_tracker,
+            registry,
         )
 
         # Status reporter (will need to be updated after brain is set)
-        components.status_reporter = self.create_status_reporter(
-            components.registry,
-            components.provider_selector,
-            components.output,
+        status_reporter = self.create_status_reporter(
+            registry,
+            provider_selector,
+            output,
             brain_name=None,  # Will be updated after brain setup
             quality_mode=self.config.quality_mode
         )
 
-        return components
+        return OrchestratorComponents(
+            output=output,
+            registry=registry,
+            background_manager=background_manager,
+            codebase_context=codebase_context,
+            cache=cache,
+            rate_tracker=rate_tracker,
+            working_memory=working_memory,
+            session_manager=session_manager,
+            provider_selector=provider_selector,
+            usage_reporter=usage_reporter,
+            status_reporter=status_reporter,
+            task_executor=task_executor,
+            context_manager=context_manager,
+            delegation_manager=delegation_manager,
+            llm_service=llm_service,
+            provider_status_tracker=provider_status_tracker,
+            model_selector=model_selector,
+        )
 
     def create_output(self) -> BaseOutputProtocol:
         """Create default output interface."""

--- a/src/scrappy/orchestrator/session.py
+++ b/src/scrappy/orchestrator/session.py
@@ -6,6 +6,7 @@ Handles saving and loading of session data including working memory and conversa
 
 from datetime import datetime
 from pathlib import Path
+from typing import Optional
 import json
 
 from ..infrastructure.utils import safe_import
@@ -54,7 +55,7 @@ class SessionManager:
         working_memory: WorkingMemoryProtocol,
         task_history: list,
         session_start: datetime,
-        conversation_history: list = None
+        conversation_history: Optional[list] = None
     ) -> str:
         """
         Save current session to disk.


### PR DESCRIPTION
Narrow orchestrator component lifecycle types (mypy M3b, scrappy-21x0)

With the manager protocols honest (M3a, PR #28), does the actual lifecycle narrowing: explicit truthiness chain in the AgentOrchestrator constructor (identical semantics to all([...]); mypy narrows), OrchestratorComponents with 17 required non-Optional parameters built via locals and constructed once in create_all_components (only factory.py constructed it), _brain/_brain_name annotated Optional (stay nullable with guards), and the two implicit-Optional conversation_history defaults fixed (core.py wrapper + SessionManager, the session-save nullability cluster).

Set-diff contract (vs .docs/mypy-baseline-21x0-postM3a.txt, line numbers stripped):
- Removed: 42 errors (35 union-attr None-side, 3 _brain/_brain_name assignments, 2 implicit-Optional defaults, save_session working_memory arg-type, old providers() return-value text) + 17 annotation-unchecked notes (OrchestratorComponents.__init__ now typed).
- Added: exactly 1 declared transformation: providers() return-value error text changes from "ProviderRegistryProtocol | None" to "ProviderRegistryProtocol" (same line; real fix is M4 providers() typing).
- Net: 275 -> 234. orchestrator/core.py: 46 -> 2, both assigned (providers() return type -> M4; providers=None default -> scrappy-72pv, a latent runtime bug needing a behavior decision).

Verification: ruff src/ tests/ clean; import walk 293 modules 0 failures; collect-only 5098; focused orchestrator tests 787 passed; full default suite 4989 passed / 2 skipped, only the known pre-existing flake.