### PR TITLE
Make manager protocols honest in both directions

### DIFF
--- a/src/scrappy/orchestrator/core.py
+++ b/src/scrappy/orchestrator/core.py
@@ -10,7 +10,7 @@ from typing import Awaitable, Callable, Optional, Iterator, AsyncIterator, TypeV
 from datetime import datetime
 from uuid import uuid4
 
-from .provider_types import ProviderRegistry, LLMResponse, LLMProviderBase
+from .provider_types import LLMResponse, LLMProviderProtocol
 from ..infrastructure.exceptions import (
     ProviderNotFoundError,
     FailureKind,
@@ -127,7 +127,7 @@ class AgentOrchestrator:
         # Core state
         self.task_history: list[dict] = []
         self.created_at = datetime.now()
-        self._brain: Optional[LLMProviderBase] = None
+        self._brain: Optional[LLMProviderProtocol] = None
         self._brain_name: Optional[str] = None
         self.context_aware = context_aware
         self.caching_enabled = enable_cache
@@ -875,7 +875,7 @@ class AgentOrchestrator:
         return self.context_manager.context
 
     @property
-    def providers(self) -> ProviderRegistry:
+    def providers(self) -> ProviderRegistryProtocol:
         """Access the provider registry."""
         return self.registry
 

--- a/src/scrappy/orchestrator/factory.py
+++ b/src/scrappy/orchestrator/factory.py
@@ -423,7 +423,7 @@ class OrchestratorFactory:
         self,
         codebase_context: ContextProvider,
         output: BaseOutputProtocol,
-        task_executor: TaskExecutor
+        task_executor: TaskExecutorProtocol
     ) -> ContextCoordinator:
         """Create default context coordinator."""
         return ContextCoordinator(

--- a/src/scrappy/orchestrator/litellm_callbacks.py
+++ b/src/scrappy/orchestrator/litellm_callbacks.py
@@ -29,8 +29,10 @@ from typing import Optional, Any, Dict, TYPE_CHECKING
 # to avoid slow litellm import at module load time.
 
 if TYPE_CHECKING:
-    from ..orchestrator.protocols import RateLimitTrackerProtocol
-    from ..orchestrator.provider_status import ProviderStatusTracker
+    from ..orchestrator.protocols import (
+        ProviderStatusTrackerProtocol,
+        RateLimitTrackerProtocol,
+    )
 
 
 def parse_gemini_rate_limit_error(error_message: str) -> Optional[Dict[str, Any]]:
@@ -139,7 +141,7 @@ class RateTrackingCallbackBase:
     def __init__(
         self,
         rate_tracker: Optional["RateLimitTrackerProtocol"] = None,
-        status_tracker: Optional["ProviderStatusTracker"] = None,
+        status_tracker: Optional["ProviderStatusTrackerProtocol"] = None,
         escalation_metrics: Optional[EscalationMetrics] = None,
     ):
         """
@@ -374,7 +376,7 @@ _RateTrackingCallback = None
 
 def create_rate_tracking_callback(
     rate_tracker: Optional["RateLimitTrackerProtocol"] = None,
-    status_tracker: Optional["ProviderStatusTracker"] = None,
+    status_tracker: Optional["ProviderStatusTrackerProtocol"] = None,
     escalation_metrics: Optional[EscalationMetrics] = None,
 ) -> "RateTrackingCallbackBase":
     """

--- a/src/scrappy/orchestrator/manager_protocols.py
+++ b/src/scrappy/orchestrator/manager_protocols.py
@@ -5,10 +5,11 @@ Defines abstract interfaces for orchestrator manager components that handle
 specific concerns like delegation, task execution, background tasks, and reporting.
 """
 
-from typing import AsyncIterator, Protocol, Dict, Any, List, Optional, Coroutine, runtime_checkable
+from typing import AsyncIterator, Protocol, Dict, Any, Optional, Coroutine, runtime_checkable
 
 from .constants import (
     DEFAULT_MAX_CONCURRENT,
+    DEFAULT_MAX_RETRIES,
     DEFAULT_MAX_TOKENS,
     DEFAULT_PROVIDER,
     DEFAULT_TEMPERATURE,
@@ -28,35 +29,48 @@ class DelegationManagerProtocol(Protocol):
 
     Implementations:
     - DelegationManager: Full delegation with retry/fallback logic
-    - MockDelegator: Returns preset responses for testing
-    - RecordingDelegator: Records delegation calls for verification
 
     Example:
         def query_llm(delegator: DelegationManagerProtocol, prompt: str) -> LLMResponse:
-            return delegator.delegate(prompt=prompt)
+            response, _ = delegator.delegate(provider_name="groq", prompt=prompt)
+            return response
     """
 
     def delegate(
         self,
-        provider_name: Optional[str] = None,
-        prompt: str = "",
+        provider_name: str,
+        prompt: str,
         model: Optional[str] = None,
         system_prompt: Optional[str] = None,
-        max_tokens: int = 1000,
-        temperature: float = 0.7,
+        max_tokens: int = DEFAULT_MAX_TOKENS,
+        temperature: float = DEFAULT_TEMPERATURE,
+        use_context: Optional[bool] = None,
+        use_cache: Optional[bool] = None,
+        intent_classification: Optional[dict] = None,
+        auto_fallback: bool = True,
+        max_retries: int = DEFAULT_MAX_RETRIES,
+        selection_type: Optional[str] = None,
+        min_context: int = 0,
         messages: Optional[list[dict]] = None,
         **kwargs: Any,
-    ) -> tuple[LLMResponse, dict[str, Any]]:
+    ) -> tuple[LLMResponse, dict]:
         """
         Delegate task to LLM provider with retry/fallback.
 
         Args:
-            provider_name: Target provider (None for auto-selection)
+            provider_name: Target provider or group hint
             prompt: The prompt to send
             model: Specific model to use
             system_prompt: System prompt for context
             max_tokens: Maximum tokens in response
             temperature: Sampling temperature
+            use_context: Override context augmentation setting
+            use_cache: Override cache setting
+            intent_classification: Intent data for semantic caching
+            auto_fallback: Deprecated compatibility parameter
+            max_retries: Maximum retry attempts per provider
+            selection_type: ModelSelectionType value for fallback filtering
+            min_context: Minimum context length for fallback filtering
             messages: Pre-built messages array (bypasses prompt/system_prompt)
             **kwargs: Additional provider-specific parameters
 
@@ -97,12 +111,15 @@ class DelegationManagerProtocol(Protocol):
 
     def stream_delegate(
         self,
-        provider_name: Optional[str] = None,
-        prompt: str = "",
+        provider_name: str,
+        prompt: str,
         model: Optional[str] = None,
         system_prompt: Optional[str] = None,
-        max_tokens: int = 1000,
-        temperature: float = 0.7,
+        max_tokens: int = DEFAULT_MAX_TOKENS,
+        temperature: float = DEFAULT_TEMPERATURE,
+        use_context: Optional[bool] = None,
+        use_cache: Optional[bool] = None,
+        min_context: int = 0,
         **kwargs: Any,
     ) -> AsyncIterator[StreamChunk]:
         """
@@ -115,32 +132,13 @@ class DelegationManagerProtocol(Protocol):
             system_prompt: System prompt for context
             max_tokens: Maximum tokens in response
             temperature: Sampling temperature
+            use_context: Override context augmentation setting
+            use_cache: Override cache setting
+            min_context: Minimum context length for fallback filtering
             **kwargs: Additional provider-specific parameters
 
         Yields:
             StreamChunk objects as they arrive
-        """
-        ...
-
-    def delegate_with_retry(
-        self,
-        prompt: str,
-        max_retries: int = 3,
-        **kwargs: Any,
-    ) -> LLMResponse:
-        """
-        Delegate with automatic retry on failure.
-
-        Args:
-            prompt: The prompt to send
-            max_retries: Maximum retry attempts
-            **kwargs: Additional delegation parameters
-
-        Returns:
-            LLMResponse with provider's response
-
-        Raises:
-            Exception: If all retries exhausted
         """
         ...
 
@@ -253,47 +251,21 @@ class TaskExecutorProtocol(Protocol):
 
     Implementations:
     - TaskExecutor: Standard task execution
-    - SyncTaskExecutor: Synchronous execution for testing
-    - MockTaskExecutor: Returns preset results
 
     Example:
-        def run_task(executor: TaskExecutorProtocol, task: Dict[str, Any]) -> Any:
-            return executor.execute(task)
+        def plan_task(executor: TaskExecutorProtocol, task: str) -> list[dict]:
+            return executor.plan(task)
     """
 
-    def execute(self, task: Dict[str, Any]) -> Any:
+    def generate_context_summary(self, context_data: str) -> str:
         """
-        Execute a task.
+        Generate a summary of codebase context.
 
         Args:
-            task: Task specification dictionary
+            context_data: Raw context data to summarize
 
         Returns:
-            Task execution result
-        """
-        ...
-
-    def execute_parallel(self, tasks: List[Dict[str, Any]]) -> List[Any]:
-        """
-        Execute multiple tasks in parallel.
-
-        Args:
-            tasks: List of task specifications
-
-        Returns:
-            List of task results in same order
-        """
-        ...
-
-    def execute_sequential(self, tasks: List[Dict[str, Any]]) -> List[Any]:
-        """
-        Execute multiple tasks sequentially.
-
-        Args:
-            tasks: List of task specifications
-
-        Returns:
-            List of task results in same order
+            Summary string
         """
         ...
 

--- a/src/scrappy/orchestrator/protocols.py
+++ b/src/scrappy/orchestrator/protocols.py
@@ -18,7 +18,7 @@ from typing import Protocol, Optional, Dict, Any, List, runtime_checkable, Async
 from pydantic import BaseModel
 
 from .model_selection import ModelSelectionType
-from .provider_types import LLMResponse, LLMProviderBase, ProviderLimits
+from .provider_types import LLMResponse, LLMProviderProtocol, ProviderLimits
 from .types import StreamChunk
 
 # Type variable for generic structured output responses
@@ -366,28 +366,11 @@ class RateLimitTrackerProtocol(Protocol):
 
     Implementations:
     - RateLimitTracker: File-based tracking with time windows
-    - InMemoryRateLimitTracker: In-memory tracking for testing
-    - UnlimitedRateLimiter: No rate limits (for testing)
 
     Example:
-        def make_request(tracker: RateLimitTrackerProtocol, provider: str) -> bool:
-            if not tracker.can_make_request(provider):
-                return False
-            tracker.record_request(provider)
-            return True
+        def track(tracker: RateLimitTrackerProtocol, provider: str, model: str) -> None:
+            tracker.record_request(provider, model, input_tokens=10, output_tokens=5)
     """
-
-    def can_make_request(self, provider: str) -> bool:
-        """
-        Check if request can be made without exceeding rate limits.
-
-        Args:
-            provider: Provider name
-
-        Returns:
-            True if request can be made, False if rate limited
-        """
-        ...
 
     def record_request(
         self,
@@ -411,48 +394,22 @@ class RateLimitTrackerProtocol(Protocol):
         """
         ...
 
-    def get_remaining(self, provider: str) -> Dict[str, int]:
+    def get_remaining_quota(
+        self,
+        provider: str,
+        model: str,
+        limits: ProviderLimits,
+    ) -> dict[str, Any]:
         """
-        Get remaining capacity before rate limits.
+        Get remaining quota for provider/model.
 
         Args:
             provider: Provider name
+            model: Model name
+            limits: Provider limits configuration
 
         Returns:
-            Dictionary containing:
-            - requests_remaining: Requests remaining in current window
-            - tokens_remaining: Tokens remaining in current window
-            - window_reset: Seconds until window resets
-        """
-        ...
-
-    def get_limits(self, provider: str) -> Optional[ProviderLimits]:
-        """
-        Get configured rate limits for provider.
-
-        Args:
-            provider: Provider name
-
-        Returns:
-            ProviderLimits if configured, None otherwise
-        """
-        ...
-
-    def reset(self, provider: Optional[str] = None) -> None:
-        """
-        Reset rate limit tracking.
-
-        Args:
-            provider: Provider to reset (None for all providers)
-        """
-        ...
-
-    def get_status(self) -> Dict[str, Any]:
-        """
-        Get rate limit status for all providers.
-
-        Returns:
-            Dictionary mapping provider names to status info
+            Dictionary with remaining quota details
         """
         ...
 
@@ -532,77 +489,11 @@ class SessionManagerProtocol(Protocol):
 
     Implementations:
     - SessionManager: File-based session persistence
-    - InMemorySessionManager: In-memory sessions for testing
-    - NullSessionManager: No session persistence
 
     Example:
-        def save_work(session: SessionManagerProtocol, data: Dict[str, Any]) -> None:
-            session.save("my_session", data)
+        def restore(session: SessionManagerProtocol) -> dict:
+            return session.load_session()
     """
-
-    def save(self, session_id: str, data: Dict[str, Any]) -> None:
-        """
-        Save session data.
-
-        Args:
-            session_id: Unique session identifier
-            data: Session data to persist
-        """
-        ...
-
-    def load(self, session_id: str) -> Optional[Dict[str, Any]]:
-        """
-        Load session data.
-
-        Args:
-            session_id: Unique session identifier
-
-        Returns:
-            Session data if found, None otherwise
-        """
-        ...
-
-    def list_sessions(self) -> List[str]:
-        """
-        List all session IDs.
-
-        Returns:
-            List of session IDs
-        """
-        ...
-
-    def delete(self, session_id: str) -> bool:
-        """
-        Delete session.
-
-        Args:
-            session_id: Unique session identifier
-
-        Returns:
-            True if session was deleted, False if not found
-        """
-        ...
-
-    def exists(self, session_id: str) -> bool:
-        """
-        Check if session exists.
-
-        Args:
-            session_id: Unique session identifier
-
-        Returns:
-            True if session exists, False otherwise
-        """
-        ...
-
-    def clear_all(self) -> int:
-        """
-        Clear all sessions.
-
-        Returns:
-            Number of sessions deleted
-        """
-        ...
 
     def save_session(
         self,
@@ -645,67 +536,11 @@ class ProviderSelectorProtocol(Protocol):
 
     Implementations:
     - ProviderSelector: Smart selection based on availability and limits
-    - RandomSelector: Random provider selection (for testing)
-    - FixedSelector: Always returns specific provider (for testing)
-    - RoundRobinSelector: Round-robin selection across providers
 
     Example:
-        def get_provider(selector: ProviderSelectorProtocol) -> str:
-            return selector.select_provider()
+        def pick(selector: ProviderSelectorProtocol, requirements: dict) -> str:
+            return selector.recommend(requirements)
     """
-
-    def select_provider(
-        self,
-        task_type: Optional[str] = None,
-        preferred: Optional[str] = None,
-        exclude: Optional[List[str]] = None,
-    ) -> str:
-        """
-        Select appropriate provider for task.
-
-        Args:
-            task_type: Type of task (affects selection)
-            preferred: Preferred provider name (used if available)
-            exclude: Providers to exclude from selection
-
-        Returns:
-            Selected provider name
-
-        Raises:
-            ValueError: If no suitable provider available
-        """
-        ...
-
-    def get_available_providers(self) -> List[str]:
-        """
-        Get list of currently available providers.
-
-        Returns:
-            List of provider names that are available
-        """
-        ...
-
-    def is_available(self, provider: str) -> bool:
-        """
-        Check if specific provider is available.
-
-        Args:
-            provider: Provider name
-
-        Returns:
-            True if provider is available, False otherwise
-        """
-        ...
-
-    def mark_unavailable(self, provider: str, duration_seconds: int = 60) -> None:
-        """
-        Temporarily mark provider as unavailable.
-
-        Args:
-            provider: Provider name
-            duration_seconds: How long to mark unavailable
-        """
-        ...
 
     def setup_brain(self, preferred_provider: Optional[str] = None) -> tuple[str, None]:
         """
@@ -754,26 +589,25 @@ class ProviderRegistryProtocol(Protocol):
 
     Implementations:
     - ProviderRegistry: Standard provider registry
-    - TestProviderRegistry: Registry with mock providers for testing
 
     Example:
-        def get_model(registry: ProviderRegistryProtocol, name: str) -> LLMProviderBase:
+        def get_model(registry: ProviderRegistryProtocol, name: str) -> LLMProviderProtocol:
             return registry.get(name)
     """
 
-    def register(self, provider: LLMProviderBase) -> None:
+    def register(self, provider: LLMProviderProtocol) -> None:
         """
         Register a provider.
 
         Args:
-            provider: LLMProviderBase instance to register
+            provider: LLMProviderProtocol instance to register
 
         Raises:
             ValueError: If provider with same name already registered
         """
         ...
 
-    def get(self, name: str) -> LLMProviderBase:
+    def get(self, name: str) -> LLMProviderProtocol:
         """
         Get provider by name.
 
@@ -781,7 +615,7 @@ class ProviderRegistryProtocol(Protocol):
             name: Provider name
 
         Returns:
-            LLMProviderBase instance
+            LLMProviderProtocol instance
 
         Raises:
             KeyError: If provider not found
@@ -794,36 +628,6 @@ class ProviderRegistryProtocol(Protocol):
 
         Returns:
             List of provider names
-        """
-        ...
-
-    def unregister(self, name: str) -> bool:
-        """
-        Unregister a provider.
-
-        Args:
-            name: Provider name
-
-        Returns:
-            True if provider was unregistered, False if not found
-        """
-        ...
-
-    def exists(self, name: str) -> bool:
-        """
-        Check if provider is registered.
-
-        Args:
-            name: Provider name
-
-        Returns:
-            True if provider is registered, False otherwise
-        """
-        ...
-
-    def clear(self) -> None:
-        """
-        Clear all registered providers.
         """
         ...
 
@@ -856,51 +660,11 @@ class WorkingMemoryProtocol(Protocol):
 
     Implementations:
     - WorkingMemory: Standard working memory with history
-    - InMemoryWorkingMemory: In-memory only (for testing)
-    - NullMemory: No memory retention (for testing)
 
     Example:
-        def remember(memory: WorkingMemoryProtocol, item: str) -> None:
-            memory.add(item)
-
-        def recall(memory: WorkingMemoryProtocol, n: int) -> List[str]:
-            return memory.get_recent(n)
+        def persist(memory: WorkingMemoryProtocol) -> dict:
+            return memory.to_dict()
     """
-
-    def add(self, content: str, metadata: Optional[Dict[str, Any]] = None) -> None:
-        """
-        Add item to working memory.
-
-        Args:
-            content: Content to remember
-            metadata: Optional metadata about the content
-        """
-        ...
-
-    def get_recent(self, n: int = 10) -> List[Dict[str, Any]]:
-        """
-        Get recent items from memory.
-
-        Args:
-            n: Number of recent items to retrieve
-
-        Returns:
-            List of recent items with metadata
-        """
-        ...
-
-    def search(self, query: str, limit: int = 5) -> List[Dict[str, Any]]:
-        """
-        Search memory for relevant items.
-
-        Args:
-            query: Search query
-            limit: Maximum items to return
-
-        Returns:
-            List of relevant items with metadata
-        """
-        ...
 
     def clear(self) -> None:
         """
@@ -908,21 +672,12 @@ class WorkingMemoryProtocol(Protocol):
         """
         ...
 
-    def summarize(self) -> str:
+    def to_dict(self) -> dict:
         """
-        Get summary of current memory state.
+        Serialize working memory to a dictionary for persistence.
 
         Returns:
-            Summary string
-        """
-        ...
-
-    def size(self) -> int:
-        """
-        Get number of items in memory.
-
-        Returns:
-            Number of items
+            Dictionary representation of memory state
         """
         ...
 
@@ -1194,7 +949,7 @@ class ProviderStatusTrackerProtocol(Protocol):
     - ProviderStatusTracker: Production implementation
     """
 
-    def on_success(self, provider: str, model: str, latency_ms: float) -> None:
+    def on_success(self, provider: str, model: str, latency_ms: float, tokens: int = 0) -> None:
         """
         Record a successful request.
 
@@ -1202,16 +957,18 @@ class ProviderStatusTrackerProtocol(Protocol):
             provider: Provider name (e.g., "groq")
             model: Full model ID (e.g., "groq/llama-3.1-8b-instant")
             latency_ms: Request latency in milliseconds
+            tokens: Total tokens used (input + output)
         """
         ...
 
-    def on_failure(self, provider: str, error: str) -> None:
+    def on_failure(self, provider: str, error: str, latency_ms: float = 0.0) -> None:
         """
         Record a failed request.
 
         Args:
             provider: Provider name (e.g., "groq")
             error: Error message
+            latency_ms: Request latency in milliseconds
         """
         ...
 

--- a/src/scrappy/orchestrator/rate_limiting/factory.py
+++ b/src/scrappy/orchestrator/rate_limiting/factory.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional, Protocol
+from typing import TYPE_CHECKING, Optional, Protocol
 
 from .tracker import RateLimitTracker
 from .storage import RateLimitStorage, FileSystemAdapter
@@ -18,6 +18,9 @@ from .protocols import (
     UserNotifierProtocol,
 )
 from ..config import OrchestratorConfig
+
+if TYPE_CHECKING:
+    from ..protocols import RateLimitTrackerProtocol
 
 
 class OutputProtocol(Protocol):
@@ -185,7 +188,7 @@ def create_rate_limit_components(
 
 
 def create_enforcement_components(
-    tracker: RateLimitTracker,
+    tracker: RateLimitTrackerProtocol,
     config: Optional[OrchestratorConfig] = None,
     output: Optional[OutputProtocol] = None,
     quiet_mode: bool = False,


### PR DESCRIPTION
Make manager protocols honest in both directions (mypy M4a, scrappy-21x0)

Reconciles the orchestrator manager protocols with the concrete implementations and current call sites. This trims fictional protocol members after call-site sweeps, adds real members current callers use, reconciles ProviderRegistryProtocol.get/register with LLMProviderProtocol, retargets factory creator params to protocols where the implementation already operates on protocol surface, and fixes core.py providers() typing.

Set-diff contract (vs .docs/mypy-baseline-21x0-postM3b.txt, line numbers stripped):
- Removed: exactly the 12 pre-declared errors.
- Added: zero unexplained additions.
- Net: 234 -> 222.

Guardrails:
- Fictional member trims were grep-proven with zero production callers.
- delegate/stream_delegate were tightened only after protocol-typed call sites were confirmed to pass provider_name and prompt.
- Added signatures are copied from implementations: WorkingMemoryProtocol.to_dict, RateLimitTrackerProtocol.get_remaining_quota, TaskExecutorProtocol.generate_context_summary, ProviderStatusTrackerProtocol on_success/on_failure params.
- No Any widening.
- Context protocols remain untouched for M4b.
- core.py providers=None remains parked as scrappy-72pv.

Verification: ruff src/ tests/ clean; pkgutil walk 293 modules / 0 failures; collect-only 5098; focused orchestrator suite 787 passed; full default suite 4989 passed / 2 skipped with only the known test_create_undo_point_subprocess_isolation flake.