### PR TITLE
Reconcile context protocols with CodebaseContext

### DIFF
--- a/src/scrappy/context/protocols.py
+++ b/src/scrappy/context/protocols.py
@@ -5,7 +5,7 @@ Defines abstract interfaces for codebase context awareness, project detection,
 file scanning, and git history operations.
 """
 
-from typing import Protocol, Dict, Any, List, Optional, Set, runtime_checkable
+from typing import Callable, Protocol, Dict, Any, List, Optional, Set, runtime_checkable
 from pathlib import Path
 from datetime import datetime
 from dataclasses import dataclass
@@ -67,86 +67,83 @@ class CodebaseContextProtocol(Protocol):
 
     Implementations:
     - CodebaseContext: Full codebase exploration and context
-    - MockContext: Preset context for testing
-    - NullContext: No context awareness
 
     Example:
-        def get_context(ctx: CodebaseContextProtocol) -> str:
-            ctx.explore()
-            return ctx.get_context()
+        def summarize(ctx: CodebaseContextProtocol) -> str:
+            if not ctx.is_explored():
+                ctx.explore()
+            return ctx.get_summary()
     """
 
-    def explore(
-        self,
-        max_files: int = 100,
-        include_patterns: Optional[List[str]] = None,
-        exclude_patterns: Optional[List[str]] = None,
-    ) -> None:
+    project_path: Path
+
+    def explore(self, force: bool = False) -> dict:
         """
         Explore codebase and build context.
 
         Args:
-            max_files: Maximum files to include
-            include_patterns: File patterns to include
-            exclude_patterns: File patterns to exclude
-        """
-        ...
-
-    def get_context(self, max_length: Optional[int] = None) -> str:
-        """
-        Get codebase context as formatted string.
-
-        Args:
-            max_length: Maximum context length in characters
+            force: Re-explore even if already explored
 
         Returns:
-            Formatted context string
+            Dictionary with exploration results
         """
         ...
 
-    def add_files(self, files: List[str]) -> None:
+    def is_explored(self) -> bool:
         """
-        Add specific files to context.
-
-        Args:
-            files: List of file paths to add
-        """
-        ...
-
-    def clear(self) -> None:
-        """
-        Clear all context.
-        """
-        ...
-
-    def get_file_count(self) -> int:
-        """
-        Get number of files in context.
+        Check if the codebase has been explored.
 
         Returns:
-            Number of files
+            True if codebase has been explored, False otherwise
         """
         ...
 
-    def get_summary(self) -> Dict[str, Any]:
+    def get_status(self) -> dict:
         """
-        Get context summary.
+        Get context status information.
 
         Returns:
-            Dictionary containing:
-            - file_count: Number of files
-            - total_size: Total size in bytes
-            - languages: Languages detected
-            - structure: Project structure
+            Dictionary with context status details
         """
         ...
 
-    def set_max_file_size(self, size: int) -> None:
+    def get_summary(self) -> str:
         """
-        Set maximum file size to include.
+        Get the project summary text.
+
+        Returns:
+            Summary string
+        """
+        ...
+
+    def generate_summary(self, llm_func: Callable[[str], str]) -> str:
+        """
+        Generate a project summary using the provided LLM function.
 
         Args:
-            size: Maximum size in bytes
+            llm_func: Function that takes a prompt and returns a summary
+
+        Returns:
+            Generated summary string
+        """
+        ...
+
+    def clear_cache(self) -> None:
+        """
+        Clear cached exploration state.
+        """
+        ...
+
+    def augment_prompt(self, user_prompt: str, include_files: bool = False) -> str:
+        """
+        Augment a user prompt with relevant codebase context.
+
+        Args:
+            user_prompt: Prompt to augment
+            include_files: Whether to include file contents
+
+        Returns:
+            Augmented prompt string
         """
         ...
 

--- a/src/scrappy/orchestrator/factory.py
+++ b/src/scrappy/orchestrator/factory.py
@@ -66,6 +66,7 @@ from .protocols import (
     LLMServiceProtocol,
     ProviderStatusTrackerProtocol,
 )
+from ..context import CodebaseContextProtocol
 from ..infrastructure.protocols import PathProviderProtocol
 from ..infrastructure.paths import ScrappyPathProvider
 
@@ -292,7 +293,7 @@ class OrchestratorFactory:
         """Create default background task manager."""
         return BackgroundTaskManager()
 
-    def create_codebase_context(self) -> ContextProvider:
+    def create_codebase_context(self) -> CodebaseContextProtocol:
         """Create default codebase context with semantic search if enabled."""
         context = CodebaseContext(self.project_path)
 
@@ -329,7 +330,7 @@ class OrchestratorFactory:
 
         return context
 
-    def create_cache(self, codebase_context: ContextProvider) -> CacheProtocol:
+    def create_cache(self, codebase_context: CodebaseContextProtocol) -> CacheProtocol:
         """Create default response cache."""
         if self._path_provider:
             cache_path = self._path_provider.response_cache_file()
@@ -341,7 +342,7 @@ class OrchestratorFactory:
             default_ttl_hours=self.cache_ttl_hours
         )
 
-    def create_rate_tracker(self, codebase_context: ContextProvider) -> RateLimitTrackerProtocol:
+    def create_rate_tracker(self, codebase_context: CodebaseContextProtocol) -> RateLimitTrackerProtocol:
         """Create default rate limit tracker with HTTP header capture."""
         if self._path_provider:
             # Ensure user dir exists and migrate any project-level rate limits
@@ -368,7 +369,7 @@ class OrchestratorFactory:
         """Create default working memory."""
         return WorkingMemory()
 
-    def create_session_manager(self, codebase_context: ContextProvider) -> SessionManagerProtocol:
+    def create_session_manager(self, codebase_context: CodebaseContextProtocol) -> SessionManagerProtocol:
         """Create default session manager."""
         return SessionManager(codebase_context.project_path, self._path_provider)
 
@@ -421,7 +422,7 @@ class OrchestratorFactory:
 
     def create_context_manager(
         self,
-        codebase_context: ContextProvider,
+        codebase_context: CodebaseContextProtocol,
         output: BaseOutputProtocol,
         task_executor: TaskExecutorProtocol
     ) -> ContextCoordinator:

--- a/src/scrappy/orchestrator/manager_protocols.py
+++ b/src/scrappy/orchestrator/manager_protocols.py
@@ -520,22 +520,11 @@ class StatusReporterProtocol(Protocol):
 
     Implementations:
     - ProviderStatusReporter: Full status reporting
-    - NullStatusReporter: No-op reporter for testing
-    - LoggingStatusReporter: Logs status instead of printing
 
     Example:
         def show_status(reporter: StatusReporterProtocol) -> None:
             reporter.print_status()
     """
-
-    def get_status(self) -> Dict[str, Any]:
-        """
-        Get current status information.
-
-        Returns:
-            Dictionary containing system status
-        """
-        ...
 
     def print_status(self) -> None:
         """
@@ -549,15 +538,6 @@ class StatusReporterProtocol(Protocol):
 
         Args:
             quality_mode: Whether quality mode is enabled
-        """
-        ...
-
-    def get_health(self) -> Dict[str, bool]:
-        """
-        Get health check results.
-
-        Returns:
-            Dictionary mapping component names to health status
         """
         ...
 

--- a/src/scrappy/orchestrator/protocols.py
+++ b/src/scrappy/orchestrator/protocols.py
@@ -19,6 +19,7 @@ from pydantic import BaseModel
 
 from .model_selection import ModelSelectionType
 from .provider_types import LLMResponse, LLMProviderProtocol, ProviderLimits
+from ..context import CodebaseContextProtocol
 from .types import StreamChunk
 
 # Type variable for generic structured output responses
@@ -225,6 +226,16 @@ class Orchestrator(Protocol):
             - total_tasks: Total tasks delegated
             - by_provider: Per-provider breakdown
             - cache_stats: Cache hit/miss statistics
+        """
+        ...
+
+    @property
+    def context(self) -> "CodebaseContextProtocol":
+        """
+        Access the underlying codebase context.
+
+        Returns:
+            CodebaseContext instance
         """
         ...
 
@@ -697,8 +708,7 @@ class ContextProvider(Protocol):
 
     Implementations:
     - CodebaseContext: Full codebase exploration and analysis
-    - MockContext: Preset context for testing
-    - NullContext: No context provided
+    - NullContext: No context provided (orchestrator_adapter.py)
 
     Example:
         def check_context(ctx: ContextProvider) -> bool:
@@ -723,6 +733,19 @@ class ContextProvider(Protocol):
 
         Returns:
             Context summary string
+        """
+        ...
+
+    def augment_prompt(self, user_prompt: str, include_files: bool = False) -> str:
+        """
+        Augment a user prompt with relevant codebase context.
+
+        Args:
+            user_prompt: Prompt to augment
+            include_files: Whether to include file contents
+
+        Returns:
+            Augmented prompt string
         """
         ...
 

--- a/src/scrappy/orchestrator_adapter.py
+++ b/src/scrappy/orchestrator_adapter.py
@@ -40,6 +40,9 @@ class NullContext:
     def get_summary(self) -> str:
         return ""
 
+    def augment_prompt(self, user_prompt: str, include_files: bool = False) -> str:
+        return user_prompt
+
 
 class AgentOrchestratorAdapter:
     """


### PR DESCRIPTION
Reconcile context protocols with CodebaseContext (mypy M4b, scrappy-21x0)

Reconciles the two stale context protocol surfaces with the concrete CodebaseContext behavior and current callers. CodebaseContextProtocol now reflects the implementation surface used by context_coordinator/factory callers: explore(force=False) -> dict, is_explored, get_status, get_summary -> str, generate_summary, clear_cache, project_path, and augment_prompt. ContextProvider stays minimal for the adapter use case and gains only augment_prompt; NullContext gets the conforming no-op.

Set-diff contract (vs .docs/mypy-baseline-21x0-postM4a.txt, line numbers stripped):
- Removed: exactly the 22 pre-declared errors.
- Added: zero additions and zero unmasked errors.
- Net: 222 -> 200.

Guardrails:
- Every added member was verified against CodebaseContext first.
- Fictional protocol members were trimmed only after call-site sweeps; production callers were zero.
- No protocol unification in this PR; follow-up debt filed as scrappy-kc3d because NullContext is a real second ContextProvider implementer.
- Factory/cli_factory fallout is limited to contract honesty.
- factory.py:402 was included as isolated M4a-pattern fictional-member cleanup for StatusReporterProtocol.
- No Any widening.

Verification: import walk 293 modules / 0 failures; collect-only 5098; ruff src/ tests/ clean; focused orchestrator+context+cli suites 2526 passed; full default suite 4989 passed / 2 skipped with only the known pre-existing flake.