### PR TITLE
Fix lazy package exports

### DIFF
--- a/src/scrappy/__init__.py
+++ b/src/scrappy/__init__.py
@@ -18,13 +18,9 @@ def __getattr__(name: str):
     """Lazy load heavy imports to avoid startup delay."""
     if name in ('OrchestratorAdapter', 'AgentOrchestratorAdapter',
                 'LLMResponse', 'ContextProvider', 'NullContext'):
-        from .orchestrator_adapter import (
-            OrchestratorAdapter,
-            AgentOrchestratorAdapter,
-            LLMResponse,
-            ContextProvider,
-            NullContext
-        )
+        from .orchestrator.protocols import ContextProvider, OrchestratorAdapter
+        from .orchestrator.provider_types import LLMResponse
+        from .orchestrator_adapter import AgentOrchestratorAdapter, NullContext
         # Cache in module globals for subsequent access
         globals().update({
             'OrchestratorAdapter': OrchestratorAdapter,

--- a/tests/test_package_exports.py
+++ b/tests/test_package_exports.py
@@ -1,0 +1,64 @@
+"""Behavior tests for the scrappy package's public lazy exports.
+
+Regression coverage for scrappy-3o7w: the lazy __getattr__ in
+src/scrappy/__init__.py imported OrchestratorAdapter from a module that no
+longer defines it, so accessing ANY of the five lazy exports raised
+ImportError while `import scrappy` itself succeeded (the break was silent
+until attribute access).
+"""
+
+import subprocess
+import sys
+
+import pytest
+
+import scrappy
+
+
+def test_every_public_export_resolves_in_fresh_interpreter():
+    """Each name in scrappy.__all__ must be accessible on a fresh import.
+
+    Runs in a subprocess so the lazy path is exercised from a cold cache,
+    exactly as a downstream consumer would hit it. One interpreter checks
+    all names; failure output names the attribute that broke.
+    """
+    script = (
+        "import scrappy\n"
+        "for name in scrappy.__all__:\n"
+        "    try:\n"
+        "        getattr(scrappy, name)\n"
+        "    except Exception as exc:\n"
+        "        raise SystemExit(f'{name}: {type(exc).__name__}: {exc}')\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert result.returncode == 0, (
+        f"public export failed to resolve: {result.stderr.strip()}"
+    )
+
+
+def test_lazy_exports_point_at_canonical_definitions():
+    """The package-level names must be the same objects as their real homes.
+
+    Guards against the export drifting to a stale copy or shim when the
+    underlying class moves modules again.
+    """
+    from scrappy.orchestrator.protocols import ContextProvider, OrchestratorAdapter
+    from scrappy.orchestrator.provider_types import LLMResponse
+    from scrappy.orchestrator_adapter import AgentOrchestratorAdapter, NullContext
+
+    assert scrappy.OrchestratorAdapter is OrchestratorAdapter
+    assert scrappy.ContextProvider is ContextProvider
+    assert scrappy.LLMResponse is LLMResponse
+    assert scrappy.AgentOrchestratorAdapter is AgentOrchestratorAdapter
+    assert scrappy.NullContext is NullContext
+
+
+def test_unknown_attribute_raises_attribute_error():
+    """__getattr__ must reject unknown names with AttributeError, not ImportError."""
+    with pytest.raises(AttributeError, match="no attribute 'DoesNotExist'"):
+        scrappy.DoesNotExist


### PR DESCRIPTION
Fix lazy package exports (scrappy-3o7w)

The package-level lazy __getattr__ imported OrchestratorAdapter from orchestrator_adapter.py, where it no longer exists. Because all five lazy exports were imported in one block, accessing any public lazy export raised ImportError even though import scrappy succeeded.

Fixes the lazy imports to use each export's canonical module:
- OrchestratorAdapter and ContextProvider from scrappy.orchestrator.protocols
- LLMResponse from scrappy.orchestrator.provider_types
- AgentOrchestratorAdapter and NullContext from scrappy.orchestrator_adapter

TDD coverage added first:
- every __all__ export resolves in a fresh interpreter
- lazy exports are identical to canonical definitions
- unknown names preserve the AttributeError contract

Verification reported by implementer: mypy set-diff 200 -> 199 with zero additions; 293-module import walk clean; collect count 5101; full suite passed with only the documented pre-existing flake.