### PR TITLE
Fix LiteLLMService close cleanup

### DIFF
--- a/src/scrappy/orchestrator/litellm_service.py
+++ b/src/scrappy/orchestrator/litellm_service.py
@@ -719,25 +719,31 @@ class LiteLLMService:
         if async_closes:
             self._run_async_closes_with_loop(async_closes, loop)
 
-    def _run_async_closes(self, closes: list) -> None:
-        """Run async close operations, waiting for completion.
+    def _get_usable_loop(self) -> Optional[asyncio.AbstractEventLoop]:
+        """Return an event loop that can run coroutines, or None.
 
-        Uses defensive approach: if we can't reliably get a working event loop,
-        we skip async cleanup. The coroutines will be garbage collected anyway.
-        Better to exit cleanly than hang indefinitely.
+        Checked BEFORE creating close coroutines: creating them with no
+        usable loop triggers 'coroutine was never awaited' warnings, and
+        garbage collection handles the sessions anyway. Better to exit
+        cleanly than hang indefinitely.
         """
         try:
             loop = asyncio.get_event_loop_policy().get_event_loop()
         except RuntimeError:
             # No event loop - coroutines will be garbage collected
             logger.debug("No event loop available for async closes")
-            return
+            return None
 
-        # Check if loop is usable
         if loop.is_closed():
             logger.debug("Event loop is closed - skipping async closes")
-            return
+            return None
 
+        return loop
+
+    def _run_async_closes_with_loop(
+        self, closes: list, loop: asyncio.AbstractEventLoop
+    ) -> None:
+        """Run async close operations on a usable loop, waiting for completion."""
         async def close_all():
             for name, coro in closes:
                 try:

--- a/tests/orchestrator/test_litellm_service.py
+++ b/tests/orchestrator/test_litellm_service.py
@@ -765,3 +765,102 @@ class TestStructuredOutput:
         """Verify DEFAULT_INSTRUCTOR_RETRIES is set to 1."""
         from scrappy.orchestrator.litellm_service import DEFAULT_INSTRUCTOR_RETRIES
         assert DEFAULT_INSTRUCTOR_RETRIES == 1
+
+
+class FakeAsyncHTTPClient:
+    """Stands in for the httpx AsyncClient litellm keeps as aclient_session."""
+
+    def __init__(self):
+        self.closed = False
+
+    async def aclose(self):
+        self.closed = True
+
+
+class FakeAiohttpSession:
+    """Stands in for the aiohttp ClientSession litellm keeps as _client_session."""
+
+    def __init__(self):
+        self.closed = False
+
+    async def close(self):
+        self.closed = True
+
+
+class TestClose:
+    """Behavior tests for close(): async HTTP sessions must actually close.
+
+    Regression for scrappy-odbo: close() called helper methods that did not
+    exist, the resulting AttributeError was swallowed by the app-level
+    except, and async session cleanup silently never ran.
+    """
+
+    @pytest.fixture
+    def litellm_module(self):
+        """Expose the litellm module with session attributes saved/restored."""
+        import litellm
+
+        saved = {
+            attr: getattr(litellm, attr, None)
+            for attr in ("client_session", "aclient_session", "_client_session")
+        }
+        yield litellm
+        for attr, value in saved.items():
+            setattr(litellm, attr, value)
+
+    @pytest.fixture
+    def owned_event_loop(self):
+        """Provide a fresh event loop installed as the current one."""
+        import asyncio
+
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        yield loop
+        if not loop.is_closed():
+            loop.close()
+        asyncio.set_event_loop(None)
+
+    def test_close_awaits_async_session_closes(self, litellm_module, owned_event_loop):
+        """With a usable loop, close() must await both async session closes."""
+        litellm_module.client_session = None
+        async_client = FakeAsyncHTTPClient()
+        aiohttp_session = FakeAiohttpSession()
+        litellm_module.aclient_session = async_client
+        litellm_module._client_session = aiohttp_session
+
+        service = make_configured_service(
+            router=MockLiteLLMRouter(), output=MockOutputForLiteLLM()
+        )
+        service.close()
+
+        assert async_client.closed is True
+        assert aiohttp_session.closed is True
+        assert litellm_module.aclient_session is None
+        assert litellm_module._client_session is None
+
+    def test_close_with_closed_loop_clears_references_without_error(
+        self, litellm_module, owned_event_loop
+    ):
+        """With no usable loop, close() clears references and lets GC clean up.
+
+        It must not raise and must not create coroutines it cannot await
+        (those trigger 'coroutine was never awaited' warnings).
+        """
+        import warnings
+
+        litellm_module.client_session = None
+        async_client = FakeAsyncHTTPClient()
+        litellm_module.aclient_session = async_client
+        litellm_module._client_session = None
+
+        owned_event_loop.close()
+
+        service = make_configured_service(
+            router=MockLiteLLMRouter(), output=MockOutputForLiteLLM()
+        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", RuntimeWarning)
+            service.close()
+
+        assert litellm_module.aclient_session is None
+        assert async_client.closed is False


### PR DESCRIPTION
Fix LiteLLMService.close() cleanup (scrappy-odbo)

LiteLLMService.close() called _get_usable_loop() and _run_async_closes_with_loop(), but those helpers were never implemented. app.py swallowed the resulting AttributeError during shutdown, so the async HTTP session cleanup path never ran.

This completes the half-applied refactor by splitting the orphaned async close behavior into:
- _get_usable_loop(): find a usable loop before creating coroutines
- _run_async_closes_with_loop(): await async close coroutines on that loop

No new lifecycle machinery. The old unused _run_async_closes helper is removed.

TDD coverage added first:
- close() awaits both async session closes when a usable loop exists
- close() clears references without creating un-awaited coroutines when the loop is closed

Verification reported by implementer: mypy set-diff 200 -> 198 with zero additions; 293-module import walk clean; collect count 5100; full suite passed with only the documented pre-existing flake.