### PR TITLE
Narrow Optional handling across config, validation, tools, and context

### DIFF
--- a/src/scrappy/agent_tools/tools/base.py
+++ b/src/scrappy/agent_tools/tools/base.py
@@ -159,6 +159,12 @@ class MemoryProvider(Protocol):
         ...
 
 
+def _default_agent_config() -> "AgentConfig":
+    """Default-config factory; deferred import avoids a circular dependency."""
+    from ...agent_config import AgentConfig
+    return AgentConfig()
+
+
 @dataclass
 class ToolContext:
     """
@@ -173,7 +179,7 @@ class ToolContext:
 
     project_root: Path
     dry_run: bool = False
-    config: Optional["AgentConfig"] = None
+    config: "AgentConfig" = field(default_factory=_default_agent_config)
     orchestrator: Optional[MemoryProvider] = None
     semantic_search: Optional["SemanticSearchProtocol"] = None
 

--- a/src/scrappy/cli/cache_manager.py
+++ b/src/scrappy/cli/cache_manager.py
@@ -79,7 +79,7 @@ class CacheManager:
         # Validate subcommand
         validation = validate_subcommand("cache", args)
         if not validation.is_valid:
-            self.io.secho(validation.error, fg=self.io.theme.error)
+            self.io.secho(validation.error_message, fg=self.io.theme.error)
             self.io.echo("Usage: /cache [clear|toggle]")
             self.io.echo("  (no args)  - Show cache statistics")
             self.io.echo("  clear      - Clear all cached responses")

--- a/src/scrappy/cli/context_commands.py
+++ b/src/scrappy/cli/context_commands.py
@@ -63,7 +63,7 @@ class CLIContextCommands:
         # Validate subcommand
         validation = validate_subcommand("context", args)
         if not validation.is_valid:
-            self.io.secho(validation.error, fg=self._theme.error)
+            self.io.secho(validation.error_message, fg=self._theme.error)
             self.io.echo("Usage: /context [refresh|clear|clearmem|toggle|add]")
             self.io.echo("  (no args)  - Show context status and working memory")
             self.io.echo("  refresh    - Force re-exploration")

--- a/src/scrappy/cli/persistence.py
+++ b/src/scrappy/cli/persistence.py
@@ -66,7 +66,7 @@ class SessionPersistence:
         # Validate subcommand
         validation = validate_subcommand("session", args)
         if not validation.is_valid:
-            self.io.secho(validation.error, fg=self.io.theme.error)
+            self.io.secho(validation.error_message, fg=self.io.theme.error)
             self.io.echo("Usage: /session [clear]")
             self.io.echo("  (no args)  - Show session info")
             self.io.echo("  clear      - Delete saved session file")

--- a/src/scrappy/cli/rate_limiter.py
+++ b/src/scrappy/cli/rate_limiter.py
@@ -94,7 +94,7 @@ class RateLimiter:
         # Validate subcommand
         validation = validate_subcommand("limits", args)
         if not validation.is_valid:
-            self.io.secho(validation.error, fg=self.io.theme.error)
+            self.io.secho(validation.error_message, fg=self.io.theme.error)
             self.io.echo("Usage: /limits [reset [provider]|<provider>]")
             self.io.echo("  (no args)     - Show all providers' usage")
             self.io.echo("  reset         - Reset all tracking data")

--- a/src/scrappy/cli/state_manager.py
+++ b/src/scrappy/cli/state_manager.py
@@ -128,7 +128,8 @@ class PlanStateManager:
 
         task = self.active_plan[self.current_task_index]
         if isinstance(task, dict):
-            io.secho(task.get('step', task.get('description', 'Task')), bold=True)
+            label = task.get('step') or task.get('description') or 'Task'
+            io.secho(label, bold=True)
             if 'description' in task and 'step' in task:
                 io.echo(f"    {task['description']}")
         else:

--- a/src/scrappy/cli/validators/subcommand.py
+++ b/src/scrappy/cli/validators/subcommand.py
@@ -33,6 +33,20 @@ class SubcommandValidationResult:
     args: str = ""
     error: Optional[str] = None
 
+    @property
+    def error_message(self) -> str:
+        """Error message of an invalid result.
+
+        Invalid results always carry an error; calling this on a valid
+        result is a programming error and raises instead of letting None
+        leak into user-facing output.
+        """
+        if self.error is None:
+            raise ValueError(
+                "error message requested from a valid SubcommandValidationResult"
+            )
+        return self.error
+
 
 # Registry of valid subcommands per command
 # Empty string is implicitly allowed for all commands (show status)

--- a/src/scrappy/context/codebase_context.py
+++ b/src/scrappy/context/codebase_context.py
@@ -521,10 +521,11 @@ class CodebaseContext:
         Returns:
             Dict with exploration results
         """
-        if self.is_explored() and not force:
+        explored_at = self.explored_at
+        if explored_at is not None and not force:
             return {
                 'status': 'cached',
-                'explored_at': self.explored_at.isoformat(),
+                'explored_at': explored_at.isoformat(),
                 'summary': self.summary
             }
 

--- a/src/scrappy/context/semantic/provider.py
+++ b/src/scrappy/context/semantic/provider.py
@@ -261,6 +261,19 @@ class LanceDBSearchProvider:
             self._db_path.mkdir(parents=True, exist_ok=True)
             self._db = lancedb.connect(self._db_path)
 
+    @property
+    def _active_embedding_func(self) -> EmbeddingFunctionProtocol:
+        """Embedding function after lazy initialization.
+
+        _ensure_schema() establishes it; requesting it earlier is a
+        programming error.
+        """
+        if self._embedding_func is None:
+            raise IndexingError(
+                "Embedding function not initialized; call _ensure_schema() first"
+            )
+        return self._embedding_func
+
     def _ensure_schema(self):
         """
         Lazy schema initialization (creates embedding func and schema).
@@ -319,7 +332,7 @@ class LanceDBSearchProvider:
         Returns:
             True if dimensions match (or can't be determined), False if mismatch
         """
-        expected_dims = self._embedding_func.ndims()
+        expected_dims = self._active_embedding_func.ndims()
 
         try:
             # Get the schema from the table
@@ -691,7 +704,7 @@ class LanceDBSearchProvider:
         texts = [c["content"] for c in chunks]
 
         t0 = time.time()
-        embeddings = list(self._embedding_func.generate_embeddings(texts))
+        embeddings = list(self._active_embedding_func.generate_embeddings(texts))
         t1 = time.time()
         result["embed_time"] = t1 - t0
 
@@ -823,7 +836,7 @@ class LanceDBSearchProvider:
         table = self._db.open_table(TABLE_NAME)
         # 1. Embed the query manually
         # Note: embed_query returns a generator, use list() + next() or standard methods
-        query_vector = self._embedding_func.generate_embeddings([query])[0]
+        query_vector = self._active_embedding_func.generate_embeddings([query])[0]
 
         # Hybrid Search: Vector (semantic) + FTS (keyword)
         try:

--- a/src/scrappy/infrastructure/config/api_keys.py
+++ b/src/scrappy/infrastructure/config/api_keys.py
@@ -281,6 +281,12 @@ class ApiKeyConfigService:
         self._persistence.save(config.to_dict())
         self._config = config
 
+    def _loaded_config(self) -> ApiKeyConfig:
+        """Return the config, lazy-loading it on first access."""
+        if self._config is None:
+            return self.load()
+        return self._config
+
     def get_key(self, env_var: str) -> Optional[str]:
         """
         Get API key by env var name.
@@ -293,9 +299,7 @@ class ApiKeyConfigService:
         Returns:
             API key value or None if not found
         """
-        if self._config is None:
-            self.load()
-        return self._config.get_key(env_var)
+        return self._loaded_config().get_key(env_var)
 
     def set_key(self, env_var: str, key: str) -> None:
         """
@@ -321,11 +325,10 @@ class ApiKeyConfigService:
         if not key_result.is_valid:
             raise ApiKeyValidationError(f"Invalid API key: {key_result.error}")
 
-        if self._config is None:
-            self.load()
+        config = self._loaded_config()
         # Use sanitized values
-        self._config.set_key(env_result.sanitized_value, key_result.sanitized_value)
-        self.save(self._config)
+        config.set_key(env_result.sanitized, key_result.sanitized)
+        self.save(config)
 
     def has_any_key(self, env_vars: list[str]) -> bool:
         """
@@ -339,9 +342,8 @@ class ApiKeyConfigService:
         Returns:
             True if any of the variables have configured keys
         """
-        if self._config is None:
-            self.load()
-        return any(self._config.has_key(ev) for ev in env_vars)
+        config = self._loaded_config()
+        return any(config.has_key(ev) for ev in env_vars)
 
     def is_disclaimer_acknowledged(self) -> bool:
         """
@@ -352,18 +354,15 @@ class ApiKeyConfigService:
         Returns:
             True if disclaimer was acknowledged
         """
-        if self._config is None:
-            self.load()
-        return self._config.disclaimer_acknowledged
+        return self._loaded_config().disclaimer_acknowledged
 
     def acknowledge_disclaimer(self) -> None:
         """
         Mark disclaimer as acknowledged and save immediately.
         """
-        if self._config is None:
-            self.load()
-        self._config.disclaimer_acknowledged = True
-        self.save(self._config)
+        config = self._loaded_config()
+        config.disclaimer_acknowledged = True
+        self.save(config)
 
     def _migrate_from_env(self, env_vars: Optional[List[str]] = None) -> int:
         """
@@ -404,7 +403,7 @@ class ApiKeyConfigService:
             if not self._config.has_key(env_var):
                 try:
                     # Set key directly on config (skip re-validation in set_key)
-                    self._config.set_key(env_var, validation_result.sanitized_value)
+                    self._config.set_key(env_var, validation_result.sanitized)
                     migrated.append(env_var)
                 except Exception as e:
                     logger.warning(f"Failed to migrate {env_var}: {e}")

--- a/src/scrappy/infrastructure/logging/logger.py
+++ b/src/scrappy/infrastructure/logging/logger.py
@@ -194,10 +194,10 @@ class StructuredLogger:
             if self._structured_only:
                 self._io.echo(safe_json_dumps(record))
             else:
-                self._output_formatted(level_name, message)
+                self._output_formatted(self._io, level_name, message)
 
-    def _output_formatted(self, level: str, message: str):
-        """Output formatted message to IO."""
+    def _output_formatted(self, io: Any, level: str, message: str):
+        """Output formatted message to the given (non-None) IO."""
         # Determine color and style
         if level == "CRITICAL":
             fg = "red"
@@ -219,9 +219,9 @@ class StructuredLogger:
             output = message
 
         if fg:
-            self._io.secho(output, fg=fg, bold=bold)
+            io.secho(output, fg=fg, bold=bold)
         else:
-            self._io.echo(output)
+            io.echo(output)
 
     def debug(self, message: str, *args, extra: Optional[Dict[str, Any]] = None):
         """

--- a/src/scrappy/infrastructure/validation/api_key.py
+++ b/src/scrappy/infrastructure/validation/api_key.py
@@ -180,7 +180,7 @@ def validate_api_key(value: str) -> ValidationResult:
     if not result.is_valid:
         return result
 
-    cleaned = result.sanitized_value
+    cleaned = result.sanitized
 
     # Additional length check for minimum
     if len(cleaned) < MIN_KEY_LENGTH:

--- a/src/scrappy/infrastructure/validation/sanitizer.py
+++ b/src/scrappy/infrastructure/validation/sanitizer.py
@@ -39,6 +39,34 @@ class ValidationResult:
     sanitized_value: Optional[str] = None
     warnings: Tuple[str, ...] = ()
 
+    @property
+    def sanitized(self) -> str:
+        """Sanitized value of a valid result.
+
+        Valid results always carry a sanitized value; calling this on an
+        invalid result is a programming error and raises instead of
+        letting None leak into string handling.
+        """
+        if self.sanitized_value is None:
+            raise ValueError(
+                "sanitized value requested from an invalid ValidationResult"
+            )
+        return self.sanitized_value
+
+    @property
+    def error_message(self) -> str:
+        """Error message of an invalid result.
+
+        Invalid results always carry an error; calling this on a valid
+        result is a programming error and raises instead of letting None
+        leak into user-facing output.
+        """
+        if self.error is None:
+            raise ValueError(
+                "error message requested from a valid ValidationResult"
+            )
+        return self.error
+
     @staticmethod
     def valid(value: str, warnings: Optional[List[str]] = None) -> "ValidationResult":
         """Create a valid result with sanitized value."""

--- a/src/scrappy/infrastructure/validation/user_input.py
+++ b/src/scrappy/infrastructure/validation/user_input.py
@@ -118,7 +118,7 @@ def _validate_command_input(value: str, max_length: int) -> ValidationResult:
     if not result.is_valid:
         return result
 
-    cleaned = result.sanitized_value
+    cleaned = result.sanitized
 
     # Commands must start with /
     if not cleaned.startswith("/"):
@@ -241,7 +241,7 @@ def validate_numeric_choice(
     if not result.is_valid:
         return result
 
-    cleaned = result.sanitized_value
+    cleaned = result.sanitized
 
     # Check if it's a number
     if not cleaned.isdigit():

--- a/src/scrappy/orchestrator/protocols.py
+++ b/src/scrappy/orchestrator/protocols.py
@@ -683,6 +683,15 @@ class WorkingMemoryProtocol(Protocol):
         """
         ...
 
+    def get_context(self) -> str:
+        """
+        Get working memory context string for prompt augmentation.
+
+        Returns:
+            Context string summarizing recent interactions
+        """
+        ...
+
     def to_dict(self) -> dict:
         """
         Serialize working memory to a dictionary for persistence.

--- a/src/scrappy/orchestrator/rate_limiting/recommender.py
+++ b/src/scrappy/orchestrator/rate_limiting/recommender.py
@@ -60,13 +60,16 @@ class RateLimitRecommender:
 
         # If scorer available, use score-based selection
         if self._scorer is not None:
-            return self._recommended_by_score(available, preferences, registry)
+            return self._recommended_by_score(
+                self._scorer, available, preferences, registry
+            )
 
         # Otherwise use legacy is_rate_limited approach
         return self._recommended_by_availability(available, preferences, registry)
 
     def _recommended_by_score(
         self,
+        scorer: QuotaScorerProtocol,
         available: list[str],
         preferences: list[str],
         registry: Any,
@@ -77,7 +80,7 @@ class RateLimitRecommender:
         Prioritizes preferred providers, but within each tier ranks by score.
         """
         # Rank all available providers by quota score
-        ranked = self._scorer.rank_providers(available, registry)
+        ranked = scorer.rank_providers(available, registry)
         if not ranked:
             return available[0] if available else None
 

--- a/src/scrappy/orchestrator_adapter.py
+++ b/src/scrappy/orchestrator_adapter.py
@@ -159,7 +159,7 @@ class AgentOrchestratorAdapter:
         self,
         provider_name: Optional[str] = None,
         prompt: str = "",
-        tools: List[dict] = None,
+        tools: Optional[List[dict]] = None,
         system_prompt: Optional[str] = None,
         max_tokens: int = 1500,
         temperature: float = 0.3,

--- a/tests/agent_tools/test_agent_tools.py
+++ b/tests/agent_tools/test_agent_tools.py
@@ -4,6 +4,7 @@ Tests for agent tools - base classes, file tools, and tool registry.
 import pytest
 from unittest.mock import Mock
 
+from scrappy.agent_config import AgentConfig
 from scrappy.agent_tools.tools.base import (
     ToolContext,
     ToolParameter,
@@ -27,7 +28,9 @@ class TestToolContext:
         context = ToolContext(project_root=temp_project_dir)
         assert context.project_root == temp_project_dir
         assert context.dry_run is False
-        assert context.config is None
+        # Omitted config falls back to defaults instead of None so tools
+        # can dereference limits without crashing.
+        assert context.config == AgentConfig()
         assert context.orchestrator is None
 
     @pytest.mark.unit


### PR DESCRIPTION
Narrow Optional handling across config, validation, tools, and context (mypy M5a, scrappy-21x0)

Optional-narrowing slice after the P1 bug fixes. This expresses existing invariants through accessors, local narrows, and honest defaults rather than suppressing errors.

Result:
- mypy: 197 -> 145
- Removed: 52 errors, 0 additions
- 51 pre-declared Optional-narrowing kills plus one same-nature bonus operator error in api_key.py
- Two originally suspected entries were dropped as wrong nature and deferred to M5b/protocol mismatch work

Notable changes:
- ValidationResult and SubcommandValidationResult now expose narrowing accessors for sanitized/error values.
- ApiKeyConfigService uses _loaded_config() to make lazy-load state visible to the type checker.
- ToolContext.config now defaults to AgentConfig() instead of None, fixing a latent runtime AttributeError path from unguarded tool dereferences.
- Narrowing accessors/parameter injection added for semantic provider embedding function, logger IO, recommender scorer, and WorkingMemoryProtocol.get_context.

Verification reported by implementer: ruff src/ tests/ clean; 293-module import walk clean; collect-only 5103; full suite 4994 passed / 2 skipped with only the documented pre-existing flake.