### PR TITLE
Fix LiteLLM fallback callback await contract

### DIFF
--- a/src/scrappy/orchestrator/litellm_callbacks.py
+++ b/src/scrappy/orchestrator/litellm_callbacks.py
@@ -294,8 +294,14 @@ class RateTrackingCallbackBase:
         """Called for streaming events. No-op for now."""
         pass
 
-    def log_success_fallback_event(self, original_model_group: str, kwargs: dict, original_exception: Exception) -> None:
-        """Called when fallback succeeds. Useful for monitoring fallback frequency."""
+    async def log_success_fallback_event(self, original_model_group: str, kwargs: dict, original_exception: Exception) -> None:
+        """Called when fallback succeeds. Useful for monitoring fallback frequency.
+
+        Must be async: litellm's CustomLogger declares this method async and
+        the router awaits it on every successful fallback. A sync override
+        would make litellm await None, raising a TypeError that litellm
+        swallows, so the event would be silently dropped.
+        """
         pass
 
     async def async_log_success_event(

--- a/tests/orchestrator/test_litellm_callbacks.py
+++ b/tests/orchestrator/test_litellm_callbacks.py
@@ -11,6 +11,7 @@ from datetime import datetime, timedelta
 from scrappy.orchestrator.litellm_callbacks import (
     RateTrackingCallback,
     EscalationMetrics,
+    create_rate_tracking_callback,
     parse_gemini_rate_limit_error,
 )
 
@@ -336,6 +337,58 @@ class TestAsyncCallbackMethods:
         )
 
         assert len(tracker.recorded_requests) == 1
+
+
+class TestFallbackEventContract:
+    """Tests for the litellm router fallback event contract.
+
+    litellm's router awaits fallback event methods on CustomLogger
+    instances (router_utils/fallback_event_handlers.py). A sync override
+    makes litellm await None, raising a TypeError that litellm swallows,
+    so the event is silently dropped.
+    """
+
+    @pytest.mark.asyncio
+    async def test_log_success_fallback_event_awaitable_via_router_contract(self):
+        """Verify the real registered callback can be awaited as litellm does.
+
+        Uses create_rate_tracking_callback so the test goes through the
+        combined RateTrackingCallbackBase + CustomLogger class, where the
+        base class override wins the MRO.
+        """
+        callback = create_rate_tracking_callback(
+            rate_tracker=MockRateLimitTracker()
+        )
+
+        # Exact calling convention of litellm's log_success_fallback_event
+        await callback.log_success_fallback_event(
+            original_model_group="fast",
+            kwargs={},
+            original_exception=Exception("rate limited"),
+        )
+
+    def test_no_sync_overrides_of_async_custom_logger_methods(self):
+        """Verify no callback method shadows an async CustomLogger method with a sync one.
+
+        Guards the whole failure mode, not just log_success_fallback_event:
+        any future sync override of an awaited litellm method would silently
+        drop events the same way.
+        """
+        import inspect
+
+        from litellm.integrations.custom_logger import CustomLogger
+
+        for name, member in vars(RateTrackingCallback).items():
+            if name.startswith("_") or not callable(member):
+                continue
+            litellm_method = getattr(CustomLogger, name, None)
+            if litellm_method is None:
+                continue
+            if inspect.iscoroutinefunction(litellm_method):
+                assert inspect.iscoroutinefunction(member), (
+                    f"{name} must be async: litellm CustomLogger declares it "
+                    f"async and awaits it, so a sync override is silently broken"
+                )
 
 
 class TestExtractProvider:


### PR DESCRIPTION
## Summary

Fixes scrappy-litellm-fallback-callback-sync-async-pihm.

LiteLLM's CustomLogger awaits log_success_fallback_event on successful fallback. RateTrackingCallbackBase overrode that method as sync def, so the combined callback class returned None, LiteLLM awaited it, swallowed TypeError, and silently dropped the fallback success event.

Changes:
- make RateTrackingCallbackBase.log_success_fallback_event async to match LiteLLM's CustomLogger contract
- add a behavior test that awaits the real combined callback from create_rate_tracking_callback using LiteLLM's calling convention
- add a guard test ensuring RateTrackingCallback methods do not shadow async CustomLogger methods with sync implementations

## Verification

Worker verification:
- mypy: 135 -> 134, exactly one removal, 0 additions
- ruff clean on touched files
- callbacks test file: 45 passed
- orchestrator + rate_limiting: 923 passed
- full default suite: 4996 passed, 2 skipped, 1 known pre-existing undo isolation failure on main