### PR TITLE
Narrow optional attributes in semantic, logging, and tool paths

### DIFF
--- a/src/scrappy/cli/error_recovery/retry.py
+++ b/src/scrappy/cli/error_recovery/retry.py
@@ -38,7 +38,7 @@ def retry_operation(
     if retry_on is None:
         retry_on = (ConnectionError, TimeoutError)
 
-    last_exception = None
+    last_exception: Optional[Exception] = None
     attempts = 0
 
     for attempt in range(max_retries):

--- a/src/scrappy/context/semantic/provider.py
+++ b/src/scrappy/context/semantic/provider.py
@@ -11,7 +11,7 @@ import math
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional, TYPE_CHECKING
 from contextlib import contextmanager
 
 # Use simple imports to avoid circular dependency messes
@@ -32,6 +32,9 @@ from ..protocols import (
 )
 from ...infrastructure.protocols import ProgressReporterProtocol
 from .config import SemanticIndexConfig
+
+if TYPE_CHECKING:
+    from .registry import EmbeddingModelInfo
 
 logger = logging.getLogger(__name__)
 
@@ -178,7 +181,7 @@ class LanceDBSearchProvider:
 
         # Model ID and info are resolved lazily when embedding function is created
         self._model_id: Optional[str] = None
-        self._model_info = None  # EmbeddingModelInfo with indexing profile
+        self._model_info: Optional["EmbeddingModelInfo"] = None  # indexing profile
 
         # DB path is determined lazily based on model selection
         # (each model gets its own subdirectory to avoid dimension conflicts)
@@ -186,7 +189,7 @@ class LanceDBSearchProvider:
         self._lock_path: Optional[Path] = None
 
         # Lazy initialization (embedding_func can be injected for testing)
-        self._db = None
+        self._db: Optional[Any] = None  # lancedb connection (lancedb is untyped)
         self._embedding_func = embedding_func  # None means lazy-load default
         self._code_schema = None
         self._is_writing = False  # Write protection flag for graceful shutdown
@@ -260,6 +263,19 @@ class LanceDBSearchProvider:
             self._resolve_model_and_paths()
             self._db_path.mkdir(parents=True, exist_ok=True)
             self._db = lancedb.connect(self._db_path)
+
+    @property
+    def _connected_db(self) -> Any:
+        """LanceDB connection after lazy initialization.
+
+        _ensure_db() establishes it; requesting it earlier is a
+        programming error.
+        """
+        if self._db is None:
+            raise RuntimeError(
+                "LanceDB connection not initialized; call _ensure_db() first"
+            )
+        return self._db
 
     @property
     def _active_embedding_func(self) -> EmbeddingFunctionProtocol:
@@ -478,7 +494,7 @@ class LanceDBSearchProvider:
         self._ensure_schema()  # Lazy-initialize embedding function and schema
 
         with self._safe_db_context():
-            table_exists = TABLE_NAME in self._db.table_names()
+            table_exists = TABLE_NAME in self._connected_db.table_names()
             logger.debug(f"Table exists: {table_exists}")
 
             if not table_exists:
@@ -486,7 +502,7 @@ class LanceDBSearchProvider:
                 self._create_and_populate(valid_files)
                 return
 
-            table = self._db.open_table(TABLE_NAME)
+            table = self._connected_db.open_table(TABLE_NAME)
 
             # Check for dimension mismatch (e.g., user switched embedding models)
             if not self._check_table_dimensions(table):
@@ -565,9 +581,9 @@ class LanceDBSearchProvider:
         logger.info(f"Creating new index from {len(valid_files)} files")
 
         # Drop if exists
-        if TABLE_NAME in self._db.table_names():
+        if TABLE_NAME in self._connected_db.table_names():
             logger.debug("Dropping existing table")
-            self._db.drop_table(TABLE_NAME)
+            self._connected_db.drop_table(TABLE_NAME)
 
         # Don't create table if no files
         if not valid_files:
@@ -576,7 +592,7 @@ class LanceDBSearchProvider:
 
         # Create table and index files (paths already validated by caller)
         logger.info(f"Creating table and indexing {len(valid_files)} files")
-        table = self._db.create_table(TABLE_NAME, schema=self._code_schema)
+        table = self._connected_db.create_table(TABLE_NAME, schema=self._code_schema)
 
         metrics = self._add_files_in_batches(table, valid_files)
 
@@ -833,7 +849,7 @@ class LanceDBSearchProvider:
 
         self._ensure_schema()  # Ensure model is loaded
 
-        table = self._db.open_table(TABLE_NAME)
+        table = self._connected_db.open_table(TABLE_NAME)
         # 1. Embed the query manually
         # Note: embed_query returns a generator, use list() + next() or standard methods
         query_vector = self._active_embedding_func.generate_embeddings([query])[0]
@@ -1005,7 +1021,7 @@ class LanceDBSearchProvider:
         """
         try:
             self._ensure_db()
-            return TABLE_NAME in self._db.table_names()
+            return TABLE_NAME in self._connected_db.table_names()
         except Exception:
             return False
 
@@ -1017,8 +1033,8 @@ class LanceDBSearchProvider:
         """
         self._ensure_db()
         with self._safe_db_context():
-            if TABLE_NAME in self._db.table_names():
-                self._db.drop_table(TABLE_NAME)
+            if TABLE_NAME in self._connected_db.table_names():
+                self._connected_db.drop_table(TABLE_NAME)
 
     def cleanup_deleted_files(self, current_files: set) -> int:
         """
@@ -1042,7 +1058,7 @@ class LanceDBSearchProvider:
         self._ensure_db()
 
         with self._safe_db_context():
-            table = self._db.open_table(TABLE_NAME)
+            table = self._connected_db.open_table(TABLE_NAME)
 
             # Get all indexed file paths (unique)
             indexed_paths = set()
@@ -1111,7 +1127,7 @@ class LanceDBSearchProvider:
         self._ensure_db()
 
         with self._safe_db_context():
-            table = self._db.open_table(TABLE_NAME)
+            table = self._connected_db.open_table(TABLE_NAME)
 
             # Delete in batches to avoid huge SQL statements
             BATCH_SIZE = 100
@@ -1159,7 +1175,7 @@ class LanceDBSearchProvider:
             # Build file_hashes from current index
             file_hashes = {}
             self._ensure_db()
-            table = self._db.open_table(TABLE_NAME)
+            table = self._connected_db.open_table(TABLE_NAME)
 
             try:
                 for batch in table.search().select(["file_path", "content_hash"]).to_batches():
@@ -1196,7 +1212,7 @@ class LanceDBSearchProvider:
 
         try:
             self._ensure_db()
-            table = self._db.open_table(TABLE_NAME)
+            table = self._connected_db.open_table(TABLE_NAME)
 
             # Count total chunks
             total_chunks = table.count_rows()

--- a/src/scrappy/infrastructure/logging/logger.py
+++ b/src/scrappy/infrastructure/logging/logger.py
@@ -79,8 +79,8 @@ class StructuredLogger:
         self._bound_context: Dict[str, Any] = {}
 
         # File handler setup
-        self._file_handler = None
-        self._log_file = None
+        self._file_handler: Optional[RotatingFileHandler] = None
+        self._log_file: Optional[Path] = None
         if log_file:
             self._setup_file_handler(log_file, max_bytes, backup_count)
 
@@ -186,8 +186,11 @@ class StructuredLogger:
                 msg=msg, args=(), exc_info=None
             )):
                 self._file_handler.doRollover()
-            self._file_handler.stream.write(msg)
-            self._file_handler.stream.flush()
+            stream = self._file_handler.stream
+            if stream is None:
+                raise RuntimeError("Log file handler stream is not open")
+            stream.write(msg)
+            stream.flush()
 
         # Output to IO
         if self._io:

--- a/src/scrappy/infrastructure/progress.py
+++ b/src/scrappy/infrastructure/progress.py
@@ -7,7 +7,12 @@ progress display strategies (Rich, logging, callbacks, silent).
 
 import logging
 import time
-from typing import Optional, Callable
+from typing import Optional, Callable, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from rich.console import Console
+    from rich.live import Live
+    from rich.status import Status
 
 from scrappy.infrastructure.output_mode import OutputModeContext
 from scrappy.infrastructure.theme import ThemeProtocol, DEFAULT_THEME
@@ -51,8 +56,8 @@ class RichProgressReporter:
                 "Use UnifiedIOProgressReporter or create_progress_reporter() factory instead."
             )
         self._theme = theme or DEFAULT_THEME
-        self._status = None
-        self._console = None
+        self._status: Optional["Status"] = None
+        self._console: Optional["Console"] = None
 
     def start(self, description: str, total: Optional[int] = None) -> None:
         """
@@ -149,8 +154,8 @@ class LiveProgressReporter:
                 "Use UnifiedIOProgressReporter or create_progress_reporter() factory instead."
             )
         self._theme = theme or DEFAULT_THEME
-        self._live = None
-        self._console = None
+        self._live: Optional["Live"] = None
+        self._console: Optional["Console"] = None
 
     def start(self, description: str, total: Optional[int] = None) -> None:
         """
@@ -254,7 +259,7 @@ class LoggingProgressReporter:
             logger_name: Logger name (defaults to module logger)
         """
         self._logger = logging.getLogger(logger_name or __name__)
-        self._total = None
+        self._total: Optional[int] = None
 
     def start(self, description: str, total: Optional[int] = None) -> None:
         """
@@ -321,7 +326,7 @@ class CallbackProgressReporter:
             callback: Function to call with progress messages
         """
         self._callback = callback
-        self._total = None
+        self._total: Optional[int] = None
 
     def start(self, description: str, total: Optional[int] = None) -> None:
         """

--- a/src/scrappy/orchestrator/cache.py
+++ b/src/scrappy/orchestrator/cache.py
@@ -66,6 +66,7 @@ class ResponseCache:
         self.output = output or self._create_default_output()
 
         # Create persistence layer if file path provided
+        self.persistence: Optional['JSONPersistence']
         if persistence:
             self.persistence = persistence
         elif cache_file:

--- a/src/scrappy/sandbox/docker_executor.py
+++ b/src/scrappy/sandbox/docker_executor.py
@@ -16,7 +16,7 @@ import re
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional, Protocol
+from typing import Any, Optional, Protocol
 
 # Import docker at module level for testability (can be mocked)
 try:
@@ -181,7 +181,7 @@ class DockerExecutor:
         self._project_dir = str(Path(project_dir).resolve())
         self._network_enabled = network_enabled
         self._image = image or self.IMAGE_NAME
-        self._container = None
+        self._container: Optional[Any] = None  # docker container (docker lib is untyped)
         self._docker_client = None
         self._available: Optional[bool] = None
 
@@ -274,6 +274,9 @@ class DockerExecutor:
             CommandResult with output and exit code
         """
         self._ensure_container()
+        container = self._container
+        if container is None:
+            raise RuntimeError("Docker container not initialized")
 
         # Build execution command
         workdir = self.CONTAINER_WORKDIR
@@ -282,7 +285,7 @@ class DockerExecutor:
 
         # Execute with timeout
         try:
-            exec_result = self._container.exec_run(
+            exec_result = container.exec_run(
                 cmd=["sh", "-c", command],
                 workdir=workdir,
                 demux=True,  # Separate stdout/stderr


### PR DESCRIPTION
## Summary

M5c for scrappy-21x0. Narrows optional attributes that were already guarded by runtime invariants and converts latent AttributeError paths into explicit RuntimeError failures.

Changes:
- add LanceDBSearchProvider._connected_db narrowing accessor, mirroring the existing _active_embedding_func pattern
- replace raw self._db call sites with the accessor
- add local narrows for the FileHandler.stream Optional type and the exec_run Optional[Any] site exposed during the slice

## Mypy set-diff

Against .docs/mypy-baseline-21x0-postPihm.txt:
- 134 -> 103
- removed exactly the declared 31 kill-list lines
- 0 additions

## Verification

Worker verification:
- import walk: 293 modules, 0 failures
- collect-only: 5105 unchanged
- ruff clean
- focused tests: 192 passed, 2 skipped
- full default suite: 4996 passed, 2 skipped, 1 known pre-existing undo isolation failure