### PR TITLE
Introduce ProviderCatalog with drift tests pinning all fact copies (P…

### DIFF
--- a/src/scrappy/orchestrator/provider_catalog.py
+++ b/src/scrappy/orchestrator/provider_catalog.py
@@ -1,0 +1,495 @@
+"""
+Provider catalog: single source of provider/model facts.
+
+Consolidates the provider and model facts currently duplicated across
+provider_definitions.PROVIDERS, model_selection.MODEL_PRIORITIES,
+litellm_config.MODEL_METADATA, litellm_config.build_model_list,
+the context fallback chains in create_litellm_router, the provider
+env-var maps, and the CLI validator/wizard copies.
+
+PR-1a status: intentionally UNWIRED. No production code imports this
+module yet; drift tests (tests/orchestrator/test_provider_catalog_drift.py)
+pin every existing copy to the catalog until follow-up PRs derive the
+copies from it and delete them.
+
+Facts are transcribed from what routing actually does on main today.
+Known divergence between the copies is represented explicitly through
+the drift-reporting methods (metadata_only_model_ids,
+unrouted_priority_model_ids, selection_router_disagreements) rather
+than corrected; any fact correction is a separate declared change.
+"""
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, Mapping, Optional, Protocol, Tuple
+
+from .provider_types import QualityRank, SpeedRank
+
+
+@dataclass(frozen=True)
+class ProviderFacts:
+    """Static facts about one provider (setup, display, and key lookup)."""
+    name: str
+    env_var: str
+    console_url: str
+    quota: str
+    description: str
+    setup_priority: int
+    supports_brain: bool
+    task_types: Tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class ModelFacts:
+    """Static facts about one model in provider/model LiteLLM id format."""
+    model_id: str
+    provider: str
+    group: str
+    context_length: int
+    speed: SpeedRank
+    quality: QualityRank
+    rpd: int
+    tpm: int
+
+
+@dataclass(frozen=True)
+class RouterEntry:
+    """One router model-list entry: group membership plus rate params."""
+    group: str
+    model_id: str
+    tpm: int
+    rpm: int
+
+
+@dataclass(frozen=True)
+class ContextFallback:
+    """Context-window fallback chain for one primary model."""
+    primary: str
+    fallbacks: Tuple[str, ...]
+
+
+class ProviderCatalogProtocol(Protocol):
+    """Contract for reading consolidated provider/model facts."""
+
+    def provider_names(self) -> Tuple[str, ...]: ...
+
+    def provider_facts(self, name: str) -> Optional[ProviderFacts]: ...
+
+    def providers_by_setup_priority(self) -> Tuple[ProviderFacts, ...]: ...
+
+    def env_var_for(self, provider_name: str) -> Optional[str]: ...
+
+    def known_provider_env_vars(self) -> Tuple[str, ...]: ...
+
+    def model_ids(self) -> Tuple[str, ...]: ...
+
+    def model_facts(self, model_id: str) -> Optional[ModelFacts]: ...
+
+    def models_in_group(self, group: str) -> Tuple[ModelFacts, ...]: ...
+
+    def selection_types(self) -> Tuple[str, ...]: ...
+
+    def priority_model_ids(self, selection_type: str) -> Tuple[str, ...]: ...
+
+    def group_for_selection_type(self, selection_type: str) -> Optional[str]: ...
+
+    def router_groups(self) -> frozenset[str]: ...
+
+    def router_entries(self) -> Tuple[RouterEntry, ...]: ...
+
+    def context_fallbacks(self) -> Tuple[ContextFallback, ...]: ...
+
+    def validation_model_for(self, provider_name: str) -> Optional[str]: ...
+
+    def validation_providers(self) -> Tuple[str, ...]: ...
+
+    def cli_provider_allowlist(self) -> frozenset[str]: ...
+
+    def metadata_only_model_ids(self) -> frozenset[str]: ...
+
+    def unrouted_priority_model_ids(self) -> frozenset[str]: ...
+
+    def selection_router_disagreements(
+        self,
+    ) -> Dict[str, Tuple[Tuple[str, ...], Tuple[str, ...]]]: ...
+
+
+class ProviderCatalog:
+    """Implements ProviderCatalogProtocol over injected fact data."""
+
+    def __init__(
+        self,
+        providers: Iterable[ProviderFacts],
+        models: Iterable[ModelFacts],
+        priorities: Mapping[str, Tuple[str, ...]],
+        selection_type_to_group: Mapping[str, str],
+        router_groups: Iterable[str],
+        router_entries: Iterable[RouterEntry],
+        context_fallbacks: Iterable[ContextFallback],
+        validation_models: Mapping[str, str],
+    ) -> None:
+        self._providers: Dict[str, ProviderFacts] = {p.name: p for p in providers}
+        self._models: Dict[str, ModelFacts] = {m.model_id: m for m in models}
+        self._priorities: Dict[str, Tuple[str, ...]] = dict(priorities)
+        self._selection_type_to_group: Dict[str, str] = dict(selection_type_to_group)
+        self._router_groups: frozenset[str] = frozenset(router_groups)
+        self._router_entries: Tuple[RouterEntry, ...] = tuple(router_entries)
+        self._context_fallbacks: Tuple[ContextFallback, ...] = tuple(context_fallbacks)
+        self._validation_models: Dict[str, str] = dict(validation_models)
+
+    def provider_names(self) -> Tuple[str, ...]:
+        return tuple(self._providers.keys())
+
+    def provider_facts(self, name: str) -> Optional[ProviderFacts]:
+        return self._providers.get(name)
+
+    def providers_by_setup_priority(self) -> Tuple[ProviderFacts, ...]:
+        return tuple(
+            sorted(self._providers.values(), key=lambda p: p.setup_priority)
+        )
+
+    def env_var_for(self, provider_name: str) -> Optional[str]:
+        facts = self._providers.get(provider_name)
+        return facts.env_var if facts is not None else None
+
+    def known_provider_env_vars(self) -> Tuple[str, ...]:
+        return tuple(p.env_var for p in self.providers_by_setup_priority())
+
+    def model_ids(self) -> Tuple[str, ...]:
+        return tuple(self._models.keys())
+
+    def model_facts(self, model_id: str) -> Optional[ModelFacts]:
+        return self._models.get(model_id)
+
+    def models_in_group(self, group: str) -> Tuple[ModelFacts, ...]:
+        return tuple(m for m in self._models.values() if m.group == group)
+
+    def selection_types(self) -> Tuple[str, ...]:
+        return tuple(self._selection_type_to_group.keys())
+
+    def priority_model_ids(self, selection_type: str) -> Tuple[str, ...]:
+        return self._priorities.get(selection_type, ())
+
+    def group_for_selection_type(self, selection_type: str) -> Optional[str]:
+        return self._selection_type_to_group.get(selection_type)
+
+    def router_groups(self) -> frozenset[str]:
+        return self._router_groups
+
+    def router_entries(self) -> Tuple[RouterEntry, ...]:
+        return self._router_entries
+
+    def context_fallbacks(self) -> Tuple[ContextFallback, ...]:
+        return self._context_fallbacks
+
+    def validation_model_for(self, provider_name: str) -> Optional[str]:
+        return self._validation_models.get(provider_name)
+
+    def validation_providers(self) -> Tuple[str, ...]:
+        return tuple(self._validation_models.keys())
+
+    def cli_provider_allowlist(self) -> frozenset[str]:
+        return frozenset(self._providers.keys())
+
+    def _routed_model_ids(self) -> frozenset[str]:
+        return frozenset(e.model_id for e in self._router_entries)
+
+    def _prioritized_model_ids(self) -> frozenset[str]:
+        return frozenset(
+            model_id for ids in self._priorities.values() for model_id in ids
+        )
+
+    def metadata_only_model_ids(self) -> frozenset[str]:
+        """Models carried in metadata but reachable by no routing path."""
+        return (
+            frozenset(self._models)
+            - self._routed_model_ids()
+            - self._prioritized_model_ids()
+        )
+
+    def unrouted_priority_model_ids(self) -> frozenset[str]:
+        """Models in a priority list but absent from the router model list."""
+        return self._prioritized_model_ids() - self._routed_model_ids()
+
+    def selection_router_disagreements(
+        self,
+    ) -> Dict[str, Tuple[Tuple[str, ...], Tuple[str, ...]]]:
+        """Selection types whose priority list differs from the router group.
+
+        Maps selection type -> (priority list, router entry order) for every
+        selection type where the two are not identical.
+        """
+        out: Dict[str, Tuple[Tuple[str, ...], Tuple[str, ...]]] = {}
+        for selection_type, group in self._selection_type_to_group.items():
+            prioritized = self.priority_model_ids(selection_type)
+            routed = tuple(
+                e.model_id for e in self._router_entries if e.group == group
+            )
+            if prioritized != routed:
+                out[selection_type] = (prioritized, routed)
+        return out
+
+
+def build_default_catalog() -> ProviderCatalog:
+    """Build the catalog with facts transcribed from the live copies.
+
+    Transcription sources (deleted in follow-up PRs once callers derive
+    from the catalog): provider_definitions.PROVIDERS,
+    litellm_config.MODEL_METADATA, model_selection.MODEL_PRIORITIES and
+    SELECTION_TYPE_TO_GROUP and MODEL_GROUPS, litellm_config.build_model_list,
+    the context fallback chains in litellm_config.create_litellm_router,
+    and setup_wizard.PROVIDER_TO_MODEL.
+    """
+    providers = (
+        ProviderFacts(
+            name="cerebras",
+            env_var="CEREBRAS_API_KEY",
+            console_url="cloud.cerebras.ai",
+            quota="14,400 RPD",
+            description="best default for agent work",
+            setup_priority=1,
+            supports_brain=True,
+            task_types=("planning", "execution", "quick", "general"),
+        ),
+        ProviderFacts(
+            name="groq",
+            env_var="GROQ_API_KEY",
+            console_url="console.groq.com/keys",
+            quota="7,000 RPD",
+            description="fast fallback for agent work",
+            setup_priority=2,
+            supports_brain=True,
+            task_types=("planning", "execution", "quick", "general"),
+        ),
+        ProviderFacts(
+            name="gemini",
+            env_var="GEMINI_API_KEY",
+            console_url="aistudio.google.com/apikey",
+            quota="varies",
+            description="overflow option when free-tier capacity matters",
+            setup_priority=3,
+            supports_brain=True,
+            task_types=("planning", "execution", "quick", "general"),
+        ),
+        ProviderFacts(
+            name="sambanova",
+            env_var="SAMBANOVA_API_KEY",
+            console_url="cloud.sambanova.ai",
+            quota="varies",
+            description="optional extra capacity",
+            setup_priority=4,
+            supports_brain=True,
+            task_types=("planning", "execution", "quick", "general"),
+        ),
+    )
+
+    models = (
+        ModelFacts(
+            model_id="groq/llama-3.1-8b-instant",
+            provider="groq",
+            group="fast",
+            context_length=131072,
+            speed=SpeedRank.VERY_FAST,
+            quality=QualityRank.GOOD,
+            rpd=7000,
+            tpm=20000,
+        ),
+        ModelFacts(
+            model_id="cerebras/llama3.1-8b",
+            provider="cerebras",
+            group="fast",
+            context_length=8192,
+            speed=SpeedRank.ULTRA_FAST,
+            quality=QualityRank.GOOD,
+            rpd=14400,
+            tpm=60000,
+        ),
+        ModelFacts(
+            model_id="cerebras/llama-3.3-70b",
+            provider="cerebras",
+            group="chat",
+            context_length=8192,
+            speed=SpeedRank.ULTRA_FAST,
+            quality=QualityRank.EXCELLENT,
+            rpd=14400,
+            tpm=60000,
+        ),
+        ModelFacts(
+            model_id="groq/llama-3.3-70b-versatile",
+            provider="groq",
+            group="chat",
+            context_length=32768,
+            speed=SpeedRank.FAST,
+            quality=QualityRank.EXCELLENT,
+            rpd=1000,
+            tpm=12000,
+        ),
+        ModelFacts(
+            model_id="sambanova/Meta-Llama-3.1-8B-Instruct",
+            provider="sambanova",
+            group="fast",
+            context_length=16384,
+            speed=SpeedRank.FAST,
+            quality=QualityRank.GOOD,
+            rpd=40,
+            tpm=100000,
+        ),
+        ModelFacts(
+            model_id="sambanova/Meta-Llama-3.3-70B-Instruct",
+            provider="sambanova",
+            group="chat",
+            context_length=131072,
+            speed=SpeedRank.ULTRA_FAST,
+            quality=QualityRank.EXCELLENT,
+            rpd=40,
+            tpm=100000,
+        ),
+        ModelFacts(
+            model_id="cerebras/qwen-3-235b-a22b-instruct-2507",
+            provider="cerebras",
+            group="instruct",
+            context_length=8192,
+            speed=SpeedRank.FAST,
+            quality=QualityRank.EXCELLENT,
+            rpd=14400,
+            tpm=60000,
+        ),
+        ModelFacts(
+            model_id="cerebras/gpt-oss-120b",
+            provider="cerebras",
+            group="instruct",
+            context_length=131072,
+            speed=SpeedRank.FAST,
+            quality=QualityRank.VERY_GOOD,
+            rpd=14400,
+            tpm=60000,
+        ),
+        ModelFacts(
+            model_id="cerebras/zai-glm-4.7",
+            provider="cerebras",
+            group="instruct",
+            context_length=131072,
+            speed=SpeedRank.FAST,
+            quality=QualityRank.VERY_GOOD,
+            rpd=14400,
+            tpm=60000,
+        ),
+        ModelFacts(
+            model_id="groq/moonshotai/kimi-k2-instruct",
+            provider="groq",
+            group="instruct",
+            context_length=131072,
+            speed=SpeedRank.ULTRA_FAST,
+            quality=QualityRank.VERY_GOOD,
+            rpd=7000,
+            tpm=20000,
+        ),
+        ModelFacts(
+            model_id="gemini/gemini-2.5-flash",
+            provider="gemini",
+            group="instruct",
+            context_length=1000000,
+            speed=SpeedRank.MODERATE,
+            quality=QualityRank.VERY_GOOD,
+            rpd=250,
+            tpm=250000,
+        ),
+    )
+
+    priorities: Dict[str, Tuple[str, ...]] = {
+        "fast": (
+            "groq/llama-3.1-8b-instant",
+            "cerebras/llama3.1-8b",
+            "sambanova/Meta-Llama-3.1-8B-Instruct",
+        ),
+        "chat": (
+            "cerebras/llama-3.3-70b",
+            "groq/llama-3.3-70b-versatile",
+        ),
+        "instruct": (
+            "cerebras/gpt-oss-120b",
+            "groq/moonshotai/kimi-k2-instruct",
+            "cerebras/zai-glm-4.7",
+            "gemini/gemini-2.5-flash",
+            "cerebras/qwen-3-235b-a22b-instruct-2507",
+        ),
+        "embed": (
+            "groq/llama-3.1-8b-instant",
+            "cerebras/llama3.1-8b",
+        ),
+    }
+
+    selection_type_to_group = {
+        "fast": "fast",
+        "chat": "chat",
+        "instruct": "instruct",
+        "embed": "fast",
+    }
+
+    router_entries = (
+        RouterEntry(group="fast", model_id="groq/llama-3.1-8b-instant", tpm=20000, rpm=30),
+        RouterEntry(group="fast", model_id="cerebras/llama3.1-8b", tpm=60000, rpm=30),
+        RouterEntry(group="fast", model_id="sambanova/Meta-Llama-3.1-8B-Instruct", tpm=100000, rpm=1),
+        RouterEntry(group="chat", model_id="gemini/gemini-2.5-flash", tpm=250000, rpm=10),
+        RouterEntry(group="chat", model_id="groq/moonshotai/kimi-k2-instruct", tpm=20000, rpm=30),
+        RouterEntry(group="instruct", model_id="cerebras/gpt-oss-120b", tpm=60000, rpm=30),
+        RouterEntry(group="instruct", model_id="groq/moonshotai/kimi-k2-instruct", tpm=20000, rpm=30),
+        RouterEntry(group="instruct", model_id="cerebras/zai-glm-4.7", tpm=60000, rpm=10),
+        RouterEntry(group="instruct", model_id="gemini/gemini-2.5-flash", tpm=250000, rpm=10),
+        RouterEntry(group="instruct", model_id="cerebras/qwen-3-235b-a22b-instruct-2507", tpm=60000, rpm=30),
+    )
+
+    context_fallbacks = (
+        ContextFallback(
+            primary="cerebras/qwen-3-235b-a22b-instruct-2507",
+            fallbacks=(
+                "cerebras/gpt-oss-120b",
+                "groq/moonshotai/kimi-k2-instruct",
+                "cerebras/zai-glm-4.7",
+                "gemini/gemini-2.5-flash",
+            ),
+        ),
+        ContextFallback(
+            primary="cerebras/gpt-oss-120b",
+            fallbacks=("gemini/gemini-2.5-flash",),
+        ),
+        ContextFallback(
+            primary="cerebras/zai-glm-4.7",
+            fallbacks=("gemini/gemini-2.5-flash",),
+        ),
+        ContextFallback(
+            primary="cerebras/llama-3.3-70b",
+            fallbacks=("groq/moonshotai/kimi-k2-instruct", "gemini/gemini-2.5-flash"),
+        ),
+        ContextFallback(
+            primary="cerebras/llama3.1-8b",
+            fallbacks=("groq/llama-3.1-8b-instant", "gemini/gemini-2.5-flash"),
+        ),
+        ContextFallback(
+            primary="groq/moonshotai/kimi-k2-instruct",
+            fallbacks=("gemini/gemini-2.5-flash",),
+        ),
+        ContextFallback(
+            primary="groq/llama-3.3-70b-versatile",
+            fallbacks=("gemini/gemini-2.5-flash",),
+        ),
+    )
+
+    validation_models = {
+        "groq": "groq/llama-3.1-8b-instant",
+        "cerebras": "cerebras/gpt-oss-120b",
+        "gemini": "gemini/gemini-2.5-flash",
+        "sambanova": "sambanova/Meta-Llama-3.1-8B-Instruct",
+        "openrouter": "openrouter/meta-llama/llama-3.1-8b-instruct:free",
+        "github_models": "azure/gpt-4o-mini",
+    }
+
+    return ProviderCatalog(
+        providers=providers,
+        models=models,
+        priorities=priorities,
+        selection_type_to_group=selection_type_to_group,
+        router_groups=("fast", "chat", "instruct"),
+        router_entries=router_entries,
+        context_fallbacks=context_fallbacks,
+        validation_models=validation_models,
+    )

--- a/tests/orchestrator/test_provider_catalog_drift.py
+++ b/tests/orchestrator/test_provider_catalog_drift.py
@@ -1,0 +1,285 @@
+"""
+Drift tests: pin every live copy of provider/model facts to the catalog.
+
+Each test derives the expected view from ProviderCatalog and asserts
+equality against one existing copy. When a follow-up PR rewires a copy
+to derive from the catalog, its drift test keeps holding (copy IS
+catalog); until then, any divergence between a copy and the catalog
+fails here instead of surfacing as routing/setup misbehavior.
+
+Known drift between the copies is pinned exactly in TestKnownDrift;
+changing those facts is a declared change, not a silent one.
+"""
+
+from typing import Dict, List, Optional
+from unittest.mock import MagicMock, patch
+
+from scrappy.orchestrator.provider_catalog import (
+    ProviderCatalog,
+    build_default_catalog,
+)
+
+from tests.helpers import MockApiKeyService
+
+
+CATALOG = build_default_catalog()
+
+ALL_KEYS = {
+    "CEREBRAS_API_KEY": "key-cerebras",
+    "GROQ_API_KEY": "key-groq",
+    "GEMINI_API_KEY": "key-gemini",
+    "SAMBANOVA_API_KEY": "key-sambanova",
+}
+
+
+class RecordingApiKeyService:
+    """Api key test double that records which key names were requested."""
+
+    def __init__(self, keys: Dict[str, str]):
+        self._keys = keys
+        self.requested: List[str] = []
+
+    def get_key(self, name: str) -> Optional[str]:
+        self.requested.append(name)
+        return self._keys.get(name)
+
+
+class TestProviderFactsDrift:
+    """Catalog vs provider_definitions, api_keys, and CLI copies."""
+
+    def test_provider_facts_match_provider_definitions(self):
+        from scrappy.orchestrator.provider_definitions import PROVIDERS
+
+        assert set(CATALOG.provider_names()) == set(PROVIDERS.keys())
+        for name, definition in PROVIDERS.items():
+            facts = CATALOG.provider_facts(name)
+            assert facts is not None
+            assert facts.env_var == definition.env_var
+            assert facts.console_url == definition.console_url
+            assert facts.quota == definition.quota
+            assert facts.description == definition.description
+            assert facts.setup_priority == definition.priority
+            assert facts.supports_brain == definition.supports_brain
+            assert list(facts.task_types) == definition.task_types
+
+    def test_setup_priority_order_matches_provider_definitions(self):
+        from scrappy.orchestrator.provider_definitions import get_provider_priority
+
+        assert [
+            p.name for p in CATALOG.providers_by_setup_priority()
+        ] == get_provider_priority()
+
+    def test_known_env_vars_match_api_keys_module(self):
+        from scrappy.infrastructure.config.api_keys import PROVIDER_ENV_VARS
+
+        assert list(CATALOG.known_provider_env_vars()) == PROVIDER_ENV_VARS
+
+    def test_cli_allowlist_matches_provider_validator(self):
+        from scrappy.cli.validators.provider import VALID_PROVIDERS
+
+        assert CATALOG.cli_provider_allowlist() == VALID_PROVIDERS
+
+    def test_validation_models_match_setup_wizard(self):
+        from scrappy.cli.setup_wizard import PROVIDER_TO_MODEL
+
+        assert {
+            provider: CATALOG.validation_model_for(provider)
+            for provider in CATALOG.validation_providers()
+        } == PROVIDER_TO_MODEL
+
+
+class TestModelFactsDrift:
+    """Catalog vs MODEL_METADATA and the model_selection constants."""
+
+    def test_model_facts_match_model_metadata(self):
+        from scrappy.orchestrator.litellm_config import MODEL_METADATA
+
+        assert set(CATALOG.model_ids()) == set(MODEL_METADATA.keys())
+        for model_id, metadata in MODEL_METADATA.items():
+            facts = CATALOG.model_facts(model_id)
+            assert facts is not None
+            assert facts.provider == metadata.provider
+            assert facts.group == metadata.group
+            assert facts.context_length == metadata.context_length
+            assert facts.speed == metadata.speed
+            assert facts.quality == metadata.quality
+            assert facts.rpd == metadata.rpd
+            assert facts.tpm == metadata.tpm
+
+    def test_priorities_match_model_selection(self):
+        from scrappy.orchestrator.model_selection import (
+            MODEL_PRIORITIES,
+            ModelSelectionType,
+        )
+
+        assert set(CATALOG.selection_types()) == {
+            t.value for t in ModelSelectionType
+        }
+        for selection_type, model_ids in MODEL_PRIORITIES.items():
+            assert (
+                list(CATALOG.priority_model_ids(selection_type.value)) == model_ids
+            )
+
+    def test_selection_type_groups_match_model_selection(self):
+        from scrappy.orchestrator.model_selection import SELECTION_TYPE_TO_GROUP
+
+        assert {
+            selection_type: CATALOG.group_for_selection_type(selection_type)
+            for selection_type in CATALOG.selection_types()
+        } == {t.value: group for t, group in SELECTION_TYPE_TO_GROUP.items()}
+
+    def test_router_groups_match_model_selection(self):
+        from scrappy.orchestrator.model_selection import MODEL_GROUPS
+
+        assert CATALOG.router_groups() == MODEL_GROUPS
+
+
+class TestRouterDerivationDrift:
+    """Catalog vs build_model_list, env-var maps, and context fallbacks."""
+
+    @staticmethod
+    def _expected_model_list(keys: Dict[str, str]) -> List[dict]:
+        expected = []
+        for entry in CATALOG.router_entries():
+            provider = entry.model_id.split("/")[0]
+            env_var = CATALOG.env_var_for(provider)
+            assert env_var is not None
+            api_key = keys.get(env_var)
+            if not api_key:
+                continue
+            expected.append({
+                "model_name": entry.group,
+                "litellm_params": {
+                    "model": entry.model_id,
+                    "api_key": api_key,
+                },
+                "tpm": entry.tpm,
+                "rpm": entry.rpm,
+            })
+        return expected
+
+    def test_build_model_list_all_keys_matches_catalog(self):
+        from scrappy.orchestrator.litellm_config import build_model_list
+
+        model_list = build_model_list(MockApiKeyService(keys=dict(ALL_KEYS)))
+
+        assert model_list == self._expected_model_list(ALL_KEYS)
+
+    def test_build_model_list_no_keys_is_empty(self):
+        from scrappy.orchestrator.litellm_config import build_model_list
+
+        assert build_model_list(MockApiKeyService(keys={})) == []
+
+    def test_build_model_list_single_provider_filters_catalog_entries(self):
+        from scrappy.orchestrator.litellm_config import build_model_list
+
+        keys = {"CEREBRAS_API_KEY": "key-cerebras"}
+        model_list = build_model_list(MockApiKeyService(keys=dict(keys)))
+
+        assert model_list == self._expected_model_list(keys)
+
+    def test_context_fallbacks_match_catalog(self):
+        from scrappy.orchestrator.litellm_config import create_litellm_router
+
+        with patch("litellm.Router") as mock_router_class:
+            create_litellm_router()
+        call_kwargs = mock_router_class.call_args[1]
+
+        assert call_kwargs["context_window_fallbacks"] == [
+            {fallback.primary: list(fallback.fallbacks)}
+            for fallback in CATALOG.context_fallbacks()
+        ]
+
+    def test_litellm_config_env_map_matches_catalog(self):
+        """get_configured_models' internal provider->key map, behaviorally."""
+        from scrappy.orchestrator.litellm_config import get_configured_models
+
+        service = RecordingApiKeyService(dict(ALL_KEYS))
+        configured = get_configured_models(service)
+
+        assert {m.model_id for m in configured} == set(CATALOG.model_ids())
+        assert set(service.requested) == set(CATALOG.known_provider_env_vars())
+
+    def test_factory_env_map_matches_catalog(self):
+        """_get_configured_models' internal provider->key map, behaviorally."""
+        from scrappy.orchestrator.factory import OrchestratorFactory
+
+        factory = OrchestratorFactory(path_provider=MagicMock())
+        service = RecordingApiKeyService(dict(ALL_KEYS))
+        configured = factory._get_configured_models(service)
+
+        expected = {
+            model_id
+            for selection_type in CATALOG.selection_types()
+            for model_id in CATALOG.priority_model_ids(selection_type)
+        }
+        assert configured == expected
+        assert set(service.requested) == set(CATALOG.known_provider_env_vars())
+
+
+class TestKnownDrift:
+    """Pin the documented divergence between the copies, exactly."""
+
+    def test_metadata_only_models_pinned(self):
+        assert CATALOG.metadata_only_model_ids() == {
+            "sambanova/Meta-Llama-3.3-70B-Instruct",
+        }
+
+    def test_unrouted_priority_models_pinned(self):
+        assert CATALOG.unrouted_priority_model_ids() == {
+            "cerebras/llama-3.3-70b",
+            "groq/llama-3.3-70b-versatile",
+        }
+
+    def test_selection_router_disagreements_pinned(self):
+        disagreements = CATALOG.selection_router_disagreements()
+
+        assert set(disagreements.keys()) == {"chat", "embed"}
+        assert disagreements["chat"] == (
+            ("cerebras/llama-3.3-70b", "groq/llama-3.3-70b-versatile"),
+            ("gemini/gemini-2.5-flash", "groq/moonshotai/kimi-k2-instruct"),
+        )
+        assert disagreements["embed"] == (
+            ("groq/llama-3.1-8b-instant", "cerebras/llama3.1-8b"),
+            (
+                "groq/llama-3.1-8b-instant",
+                "cerebras/llama3.1-8b",
+                "sambanova/Meta-Llama-3.1-8B-Instruct",
+            ),
+        )
+
+
+class TestCatalogLookupBehavior:
+    """Behavior of catalog lookups on unknown and boundary inputs."""
+
+    def test_unknown_provider_returns_none(self):
+        assert CATALOG.provider_facts("nope") is None
+        assert CATALOG.env_var_for("nope") is None
+        assert CATALOG.validation_model_for("nope") is None
+
+    def test_unknown_model_returns_none(self):
+        assert CATALOG.model_facts("nope/nothing") is None
+
+    def test_unknown_selection_type_returns_empty(self):
+        assert CATALOG.priority_model_ids("nope") == ()
+        assert CATALOG.group_for_selection_type("nope") is None
+
+    def test_unknown_group_returns_empty(self):
+        assert CATALOG.models_in_group("nope") == ()
+
+    def test_empty_catalog_reports_no_facts_and_no_drift(self):
+        empty = ProviderCatalog(
+            providers=(),
+            models=(),
+            priorities={},
+            selection_type_to_group={},
+            router_groups=(),
+            router_entries=(),
+            context_fallbacks=(),
+            validation_models={},
+        )
+        assert empty.provider_names() == ()
+        assert empty.model_ids() == ()
+        assert empty.known_provider_env_vars() == ()
+        assert empty.metadata_only_model_ids() == frozenset()
+        assert empty.selection_router_disagreements() == {}


### PR DESCRIPTION
…R-1a)

New ProviderCatalogProtocol + ProviderCatalog consolidating provider/model facts currently duplicated across provider_definitions, MODEL_METADATA, MODEL_PRIORITIES, build_model_list, the router context fallbacks, the provider env-var maps, and the CLI validator/wizard copies.

Intentionally unwired: no production code imports the catalog yet. 23 drift tests pin every existing copy to the catalog until follow-up PRs derive the copies from it. Known drift is represented explicitly, not corrected: sambanova 70B is metadata-only, chat/embed selection lists diverge from the router group entries.

Verification: mypy set-diff vs postM5c baseline = 0 removals / 0 additions (103); import walk 294 modules / 0 failures (+1 new module); collect 5128 (+23); ruff clean; full default suite 5019 passed / 2 skipped / only the known pre-existing flake.

Bead: scrappy-provider-catalog-single-source-b7n4
Plan: provider-reliability-backbone rev 2, PR-1a guardrails