### PR TITLE
Fix undo git metadata paths for git worktree layouts

### DIFF
--- a/src/scrappy/undo.py
+++ b/src/scrappy/undo.py
@@ -60,11 +60,7 @@ class UndoState:
 
 
 # Lock configuration
-LOCK_PATH = Path(".git/scrappy.lock")
 LOCK_TIMEOUT = 30  # seconds
-
-# Persistence configuration
-UNDO_STATE_PATH = Path(".git/scrappy/undo-states.json")
 
 
 def _run(cmd: str, check: bool = True) -> subprocess.CompletedProcess[str]:
@@ -89,6 +85,64 @@ def _run(cmd: str, check: bool = True) -> subprocess.CompletedProcess[str]:
         stdin=subprocess.DEVNULL,  # Prevent terminal interaction in TUI worker threads
     )
     return result
+
+
+# =============================================================================
+# Git Metadata Path Resolution
+# =============================================================================
+#
+# Never build git metadata paths from a literal ".git/" prefix: in a linked
+# git worktree, <worktree>/.git is a FILE containing a "gitdir:" pointer, and
+# the real metadata lives elsewhere. Resolution rules used here:
+#
+# Per-worktree git dir (git rev-parse --git-dir):
+#   MERGE_HEAD, REBASE_HEAD, CHERRY_PICK_HEAD, rebase-merge, rebase-apply
+#   (in-progress operation state is tracked per worktree), plus scrappy's
+#   own lock and undo-state files (an undo point captures per-worktree
+#   state: HEAD, branch, and working tree).
+#
+# Common git dir shared by all worktrees (git rev-parse --git-common-dir):
+#   shallow (a clone-wide property).
+#
+# In a normal clone both resolve to ".git", so behavior there is unchanged.
+
+
+def _resolve_git_dir(flag: str) -> Path:
+    """Resolve a git metadata directory via git rev-parse.
+
+    Args:
+        flag: Either "--git-dir" or "--git-common-dir".
+
+    Raises:
+        UndoError: If the current directory is not inside a git repository.
+    """
+    result = _run(f"git rev-parse {flag}", check=False)
+    if result.returncode != 0:
+        raise UndoError(
+            f"Cannot resolve git directory ({flag}): "
+            f"not inside a git repository?"
+        )
+    return Path(result.stdout.strip())
+
+
+def _git_dir() -> Path:
+    """Per-worktree git dir (".git" in a normal clone)."""
+    return _resolve_git_dir("--git-dir")
+
+
+def _git_common_dir() -> Path:
+    """Git dir shared across worktrees (same as _git_dir in a normal clone)."""
+    return _resolve_git_dir("--git-common-dir")
+
+
+def _lock_path() -> Path:
+    """Location of the scrappy undo lock file."""
+    return _git_dir() / "scrappy.lock"
+
+
+def _undo_state_path() -> Path:
+    """Location of the persisted undo states file."""
+    return _git_dir() / "scrappy" / "undo-states.json"
 
 
 # =============================================================================
@@ -132,7 +186,7 @@ def has_staged_changes() -> bool:
 
 def is_shallow_clone() -> bool:
     """Check if this is a shallow clone."""
-    return Path(".git/shallow").exists()
+    return (_git_common_dir() / "shallow").exists()
 
 
 # =============================================================================
@@ -150,12 +204,13 @@ def undo_lock() -> Iterator[None]:
     Raises:
         UndoError: If lock cannot be acquired within LOCK_TIMEOUT seconds
     """
+    lock_path = _lock_path()
     start = time.time()
 
     while True:
         try:
             # Atomic file creation - fails if file exists (no TOCTOU race)
-            fd = os.open(str(LOCK_PATH), os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+            fd = os.open(str(lock_path), os.O_CREAT | os.O_EXCL | os.O_WRONLY)
             os.write(fd, str(os.getpid()).encode())
             os.close(fd)
             break  # Lock acquired
@@ -163,14 +218,14 @@ def undo_lock() -> Iterator[None]:
             if time.time() - start > LOCK_TIMEOUT:
                 raise UndoError(
                     f"Another scrappy process holds the lock. "
-                    f"If this is stale, remove {LOCK_PATH}"
+                    f"If this is stale, remove {lock_path}"
                 )
             time.sleep(0.1)
 
     try:
         yield
     finally:
-        LOCK_PATH.unlink(missing_ok=True)
+        lock_path.unlink(missing_ok=True)
 
 
 # =============================================================================
@@ -184,17 +239,19 @@ def check_undo_preconditions() -> None:
     Raises:
         UndoError: If in the middle of a merge, rebase, or cherry-pick
     """
-    # Cannot create undo during merge/rebase/cherry-pick
+    # Cannot create undo during merge/rebase/cherry-pick.
+    # These all live in the per-worktree git dir.
+    git_dir = _git_dir()
     problem_indicators = [
-        (".git/MERGE_HEAD", "merge"),
-        (".git/REBASE_HEAD", "rebase"),
-        (".git/CHERRY_PICK_HEAD", "cherry-pick"),
-        (".git/rebase-merge", "interactive rebase"),
-        (".git/rebase-apply", "rebase/am"),
+        ("MERGE_HEAD", "merge"),
+        ("REBASE_HEAD", "rebase"),
+        ("CHERRY_PICK_HEAD", "cherry-pick"),
+        ("rebase-merge", "interactive rebase"),
+        ("rebase-apply", "rebase/am"),
     ]
 
-    for path, operation in problem_indicators:
-        if Path(path).exists():
+    for name, operation in problem_indicators:
+        if (git_dir / name).exists():
             raise UndoError(
                 f"Cannot create undo point during active {operation}. "
                 f"Complete or abort the {operation} first."
@@ -372,21 +429,23 @@ def undo(n: int = 1, force: bool = False) -> None:
 
 def persist_undo_state(state: UndoState) -> None:
     """Add state to persistent storage."""
-    UNDO_STATE_PATH.parent.mkdir(parents=True, exist_ok=True)
+    state_path = _undo_state_path()
+    state_path.parent.mkdir(parents=True, exist_ok=True)
 
     states = load_undo_states()
     states.append(state)
 
     data = {"states": [asdict(s) for s in states]}
-    UNDO_STATE_PATH.write_text(json.dumps(data, indent=2, default=str))
+    state_path.write_text(json.dumps(data, indent=2, default=str))
 
 
 def load_undo_states() -> list[UndoState]:
     """Load all undo states from storage."""
-    if not UNDO_STATE_PATH.exists():
+    state_path = _undo_state_path()
+    if not state_path.exists():
         return []
 
-    data = json.loads(UNDO_STATE_PATH.read_text())
+    data = json.loads(state_path.read_text())
     states = []
     for s in data.get("states", []):
         # Convert datetime string back to datetime object
@@ -402,7 +461,7 @@ def remove_undo_state(state: UndoState) -> None:
     states = [s for s in states if s.ref != state.ref]
 
     data = {"states": [asdict(s) for s in states]}
-    UNDO_STATE_PATH.write_text(json.dumps(data, indent=2, default=str))
+    _undo_state_path().write_text(json.dumps(data, indent=2, default=str))
 
 
 def get_undo_limit() -> int:
@@ -432,4 +491,4 @@ def prune_old_undo_states(keep: Optional[int] = None) -> None:
     # Keep only newest
     states = states[-keep:]
     data = {"states": [asdict(s) for s in states]}
-    UNDO_STATE_PATH.write_text(json.dumps(data, indent=2, default=str))
+    _undo_state_path().write_text(json.dumps(data, indent=2, default=str))

--- a/tests/test_undo.py
+++ b/tests/test_undo.py
@@ -12,7 +12,6 @@ import os
 import pytest
 from dataclasses import asdict
 from datetime import datetime
-from pathlib import Path
 from unittest.mock import patch, MagicMock
 
 from scrappy.undo import (
@@ -25,6 +24,7 @@ from scrappy.undo import (
     get_undo_limit,
     has_untracked,
     is_dirty,
+    is_shallow_clone,
     load_undo_states,
     undo,
     undo_lock,
@@ -133,68 +133,39 @@ class TestCheckPreconditions:
         """
         git_dir = temp_git_dir / ".git"
 
-        # Ensure no problem indicators exist
-        assert not (git_dir / "MERGE_HEAD").exists()
-        assert not (git_dir / "REBASE_HEAD").exists()
-        assert not (git_dir / "CHERRY_PICK_HEAD").exists()
-        assert not (git_dir / "rebase-merge").exists()
-        assert not (git_dir / "rebase-apply").exists()
-
-        # Should not raise
-        with patch("scrappy.undo.Path") as mock_path:
-            mock_path.return_value.exists.return_value = False
-            check_undo_preconditions()
+        with patch("scrappy.undo._git_dir", return_value=git_dir):
+            check_undo_preconditions()  # Should not raise
 
     @pytest.mark.unit
     def test_check_preconditions_merge(self, temp_git_dir):
         """
         Precondition check should raise during active merge.
 
-        When MERGE_HEAD exists, creating an undo point is unsafe.
+        When MERGE_HEAD exists in the git dir, creating an undo point
+        is unsafe.
         """
         git_dir = temp_git_dir / ".git"
-        merge_head = git_dir / "MERGE_HEAD"
-        merge_head.write_text("abc123\n")
+        (git_dir / "MERGE_HEAD").write_text("abc123\n")
 
-        with patch("scrappy.undo.Path") as mock_path:
+        with patch("scrappy.undo._git_dir", return_value=git_dir):
+            with pytest.raises(UndoError) as exc_info:
+                check_undo_preconditions()
 
-            def path_exists(p):
-                return ".git/MERGE_HEAD" in str(p)
-
-            mock_path.return_value.exists.side_effect = lambda: path_exists(
-                mock_path.call_args[0][0] if mock_path.call_args else ""
-            )
-
-            # Direct test - create actual file structure
-            with patch.object(Path, "exists", return_value=True):
-                with pytest.raises(UndoError) as exc_info:
-                    # Create a path object that will return True for exists()
-                    with patch("scrappy.undo.Path") as mock_p:
-                        mock_instance = MagicMock()
-                        mock_instance.exists.return_value = True
-                        mock_p.return_value = mock_instance
-                        check_undo_preconditions()
-
-                assert "merge" in str(exc_info.value).lower()
+        assert "merge" in str(exc_info.value).lower()
 
     @pytest.mark.unit
     def test_check_preconditions_rebase(self, temp_git_dir):
         """
         Precondition check should raise during active rebase.
         """
-        with patch("scrappy.undo.Path") as mock_path:
-            # First call returns False (MERGE_HEAD), second returns True (REBASE_HEAD)
-            mock_instance = MagicMock()
-            exists_returns = [False, True]  # Skip MERGE_HEAD, catch REBASE_HEAD
-            mock_instance.exists.side_effect = lambda: exists_returns.pop(
-                0
-            ) if exists_returns else False
-            mock_path.return_value = mock_instance
+        git_dir = temp_git_dir / ".git"
+        (git_dir / "REBASE_HEAD").write_text("abc123\n")
 
+        with patch("scrappy.undo._git_dir", return_value=git_dir):
             with pytest.raises(UndoError) as exc_info:
                 check_undo_preconditions()
 
-            assert "rebase" in str(exc_info.value).lower()
+        assert "rebase" in str(exc_info.value).lower()
 
 
 # =============================================================================
@@ -306,21 +277,16 @@ class TestHelperFunctions:
     @pytest.mark.unit
     def test_is_shallow_clone_false(self, temp_git_dir):
         """is_shallow_clone returns False for normal clones."""
-        with patch("scrappy.undo.Path") as mock_path:
-            mock_path.return_value.exists.return_value = False
-            # Actually test against temp dir
-            assert not (temp_git_dir / ".git" / "shallow").exists()
+        with patch("scrappy.undo._git_common_dir", return_value=temp_git_dir / ".git"):
+            assert not is_shallow_clone()
 
     @pytest.mark.unit
     def test_is_shallow_clone_true(self, temp_git_dir):
         """is_shallow_clone returns True for shallow clones."""
-        shallow_file = temp_git_dir / ".git" / "shallow"
-        shallow_file.write_text("abc123\n")
+        (temp_git_dir / ".git" / "shallow").write_text("abc123\n")
 
-        with patch("scrappy.undo.Path") as mock_path:
-            mock_path.return_value.exists.return_value = True
-            # Actually test against temp dir
-            assert shallow_file.exists()
+        with patch("scrappy.undo._git_common_dir", return_value=temp_git_dir / ".git"):
+            assert is_shallow_clone()
 
 
 # =============================================================================
@@ -365,7 +331,7 @@ class TestUndoStatePersistence:
     @pytest.mark.unit
     def test_load_undo_states_empty(self, temp_git_dir):
         """load_undo_states returns empty list when file doesn't exist."""
-        with patch("scrappy.undo.UNDO_STATE_PATH", temp_git_dir / ".git" / "scrappy" / "undo-states.json"):
+        with patch("scrappy.undo._undo_state_path", return_value=temp_git_dir / ".git" / "scrappy" / "undo-states.json"):
             result = load_undo_states()
             assert result == []
 
@@ -397,7 +363,7 @@ class TestUndoLock:
         """Lock should create lock file during context."""
         lock_path = temp_git_dir / ".git" / "scrappy.lock"
 
-        with patch("scrappy.undo.LOCK_PATH", lock_path):
+        with patch("scrappy.undo._lock_path", return_value=lock_path):
             with patch("scrappy.undo.LOCK_TIMEOUT", 1):
                 with undo_lock():
                     assert lock_path.exists()
@@ -410,7 +376,7 @@ class TestUndoLock:
         """Lock file should be removed even on exception."""
         lock_path = temp_git_dir / ".git" / "scrappy.lock"
 
-        with patch("scrappy.undo.LOCK_PATH", lock_path):
+        with patch("scrappy.undo._lock_path", return_value=lock_path):
             try:
                 with undo_lock():
                     assert lock_path.exists()
@@ -436,7 +402,7 @@ class TestUndoEdgeCases:
         state_file.parent.mkdir(parents=True, exist_ok=True)
         state_file.write_text('{"states": []}')
 
-        with patch("scrappy.undo.UNDO_STATE_PATH", state_file):
+        with patch("scrappy.undo._undo_state_path", return_value=state_file):
             with pytest.raises(UndoError) as exc_info:
                 undo()
             assert "No undo points" in str(exc_info.value)
@@ -452,7 +418,7 @@ class TestUndoEdgeCases:
         data = {"states": [state_dict]}  # Only 1 state
         state_file.write_text(json.dumps(data))
 
-        with patch("scrappy.undo.UNDO_STATE_PATH", state_file):
+        with patch("scrappy.undo._undo_state_path", return_value=state_file):
             with pytest.raises(UndoError) as exc_info:
                 undo(n=5)  # Request 5th point but only 1 exists
             assert "Only 1 undo points available" in str(exc_info.value)
@@ -470,7 +436,7 @@ class TestUndoEdgeCases:
 
         wrong_path = "/some/other/path"
 
-        with patch("scrappy.undo.UNDO_STATE_PATH", state_file):
+        with patch("scrappy.undo._undo_state_path", return_value=state_file):
             with patch("os.getcwd", return_value=wrong_path):
                 with pytest.raises(UndoError) as exc_info:
                     undo()
@@ -501,8 +467,8 @@ class TestCreateUndoPointBehavior:
             "update-ref": (0, ""),
         }
 
-        with patch("scrappy.undo.LOCK_PATH", lock_path):
-            with patch("scrappy.undo.UNDO_STATE_PATH", state_path):
+        with patch("scrappy.undo._lock_path", return_value=lock_path):
+            with patch("scrappy.undo._undo_state_path", return_value=state_path):
                 with patch("scrappy.undo.check_undo_preconditions"):
                     with patch("scrappy.undo.is_shallow_clone", return_value=False):
                         with patch("scrappy.undo.subprocess.run", side_effect=mock_git_run(command_results)):
@@ -528,8 +494,8 @@ class TestCreateUndoPointBehavior:
             "update-ref": (0, ""),
         }
 
-        with patch("scrappy.undo.LOCK_PATH", lock_path):
-            with patch("scrappy.undo.UNDO_STATE_PATH", state_path):
+        with patch("scrappy.undo._lock_path", return_value=lock_path):
+            with patch("scrappy.undo._undo_state_path", return_value=state_path):
                 with patch("scrappy.undo.check_undo_preconditions"):
                     with patch("scrappy.undo.is_shallow_clone", return_value=False):
                         with patch("scrappy.undo.subprocess.run", side_effect=mock_git_run(command_results)):
@@ -572,8 +538,8 @@ class TestCreateUndoPointBehavior:
                 result.stdout = ""
             return result
 
-        with patch("scrappy.undo.LOCK_PATH", lock_path):
-            with patch("scrappy.undo.UNDO_STATE_PATH", state_path):
+        with patch("scrappy.undo._lock_path", return_value=lock_path):
+            with patch("scrappy.undo._undo_state_path", return_value=state_path):
                 with patch("scrappy.undo.check_undo_preconditions"):
                     with patch("scrappy.undo.is_shallow_clone", return_value=False):
                         with patch("scrappy.undo.subprocess.run", side_effect=tracking_side_effect):
@@ -618,8 +584,8 @@ class TestCreateUndoPointBehavior:
                 result.stdout = ""
             return result
 
-        with patch("scrappy.undo.LOCK_PATH", lock_path):
-            with patch("scrappy.undo.UNDO_STATE_PATH", state_path):
+        with patch("scrappy.undo._lock_path", return_value=lock_path):
+            with patch("scrappy.undo._undo_state_path", return_value=state_path):
                 with patch("scrappy.undo.check_undo_preconditions"):
                     with patch("scrappy.undo.is_shallow_clone", return_value=False):
                         with patch("scrappy.undo.subprocess.run", side_effect=tracking_side_effect):
@@ -648,7 +614,7 @@ class TestUndoNValidation:
         data = {"states": [state_dict]}
         state_file.write_text(json.dumps(data))
 
-        with patch("scrappy.undo.UNDO_STATE_PATH", state_file):
+        with patch("scrappy.undo._undo_state_path", return_value=state_file):
             with pytest.raises(UndoError) as exc_info:
                 undo(n=0)
             assert "n must be >= 1" in str(exc_info.value)
@@ -664,7 +630,7 @@ class TestUndoNValidation:
         data = {"states": [state_dict]}
         state_file.write_text(json.dumps(data))
 
-        with patch("scrappy.undo.UNDO_STATE_PATH", state_file):
+        with patch("scrappy.undo._undo_state_path", return_value=state_file):
             with pytest.raises(UndoError) as exc_info:
                 undo(n=-1)
             assert "n must be >= 1" in str(exc_info.value)
@@ -708,8 +674,8 @@ class TestUndoWipUnwrap:
 
             return result
 
-        with patch("scrappy.undo.UNDO_STATE_PATH", state_file):
-            with patch("scrappy.undo.LOCK_PATH", lock_path):
+        with patch("scrappy.undo._undo_state_path", return_value=state_file):
+            with patch("scrappy.undo._lock_path", return_value=lock_path):
                 with patch("os.getcwd", return_value=str(temp_git_dir)):
                     with patch("scrappy.undo.subprocess.run", side_effect=tracking_side_effect):
                         undo()

--- a/tests/test_undo_git_layouts.py
+++ b/tests/test_undo_git_layouts.py
@@ -1,0 +1,189 @@
+"""
+Behavior tests for undo git metadata path resolution.
+
+These tests run real git against hermetic repos under tmp_path to prove
+undo works in both git repository layouts:
+
+- normal clone: .git is a directory
+- linked worktree: .git is a FILE containing a "gitdir:" pointer, and
+  metadata lives under <main>/.git/worktrees/<name>
+
+Regression coverage for scrappy-undo-broken-in-git-worktrees-aqzv: the old
+code built paths from a literal ".git/" prefix, so create_undo_point()
+raised NotADirectoryError inside a worktree, and merge/rebase detection
+probed files that never exist there.
+"""
+
+import subprocess
+
+import pytest
+
+from scrappy.undo import (
+    UndoError,
+    check_undo_preconditions,
+    create_undo_point,
+    is_shallow_clone,
+    load_undo_states,
+    undo,
+)
+
+
+def _git(cwd, *args):
+    """Run git in cwd, raising on failure. Returns stripped stdout."""
+    result = subprocess.run(
+        ["git", *args], cwd=cwd, check=True, capture_output=True, text=True
+    )
+    return result.stdout.strip()
+
+
+@pytest.fixture
+def repo(tmp_path):
+    """A real git repository with one commit (normal .git directory layout)."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q", "-b", "main")
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "user.name", "Test")
+    _git(repo, "config", "commit.gpgsign", "false")
+    (repo / "file.txt").write_text("base\n")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-q", "-m", "base")
+    return repo
+
+
+@pytest.fixture
+def worktree(repo, tmp_path):
+    """A linked git worktree of repo (.git is a file, not a directory)."""
+    wt = tmp_path / "wt"
+    _git(repo, "worktree", "add", "-q", str(wt), "-b", "wt-branch")
+    return wt
+
+
+class TestNormalCloneLayout:
+    """Undo behavior is preserved where .git is a plain directory."""
+
+    @pytest.mark.unit
+    def test_create_and_undo_round_trip(self, repo, monkeypatch):
+        """Dirty state survives create_undo_point + agent changes + undo."""
+        monkeypatch.chdir(repo)
+        (repo / "file.txt").write_text("user edit\n")
+
+        create_undo_point()
+
+        # Simulate agent work: commit on top of the WIP snapshot
+        (repo / "file.txt").write_text("agent edit\n")
+        _git(repo, "add", ".")
+        _git(repo, "commit", "-q", "-m", "agent")
+
+        undo()
+
+        assert (repo / "file.txt").read_text() == "user edit\n"
+        assert _git(repo, "symbolic-ref", "--short", "HEAD") == "main"
+
+    @pytest.mark.unit
+    def test_state_file_written_under_git_dir(self, repo, monkeypatch):
+        """Undo states land in .git/scrappy/, same location as before the fix."""
+        monkeypatch.chdir(repo)
+
+        create_undo_point()
+
+        assert (repo / ".git" / "scrappy" / "undo-states.json").exists()
+        # Lock is released after the operation
+        assert not (repo / ".git" / "scrappy.lock").exists()
+
+    @pytest.mark.unit
+    def test_merge_in_progress_blocks_undo_point(self, repo, monkeypatch):
+        """An active merge (MERGE_HEAD present) blocks undo point creation."""
+        monkeypatch.chdir(repo)
+        (repo / ".git" / "MERGE_HEAD").write_text("deadbeef\n")
+
+        with pytest.raises(UndoError, match="merge"):
+            check_undo_preconditions()
+
+
+class TestWorktreeLayout:
+    """Regression tests: these fail on code that hardcodes '.git/...' paths."""
+
+    @pytest.mark.unit
+    def test_create_undo_point_in_worktree(self, worktree, monkeypatch):
+        """
+        create_undo_point works where .git is a file.
+
+        Old code raised NotADirectoryError('.git/scrappy.lock') here.
+        """
+        assert (worktree / ".git").is_file()  # worktree layout precondition
+
+        monkeypatch.chdir(worktree)
+        (worktree / "file.txt").write_text("wt edit\n")
+
+        state = create_undo_point()
+
+        assert state.branch == "wt-branch"
+        assert state.is_wip is True
+
+    @pytest.mark.unit
+    def test_undo_round_trip_in_worktree(self, worktree, monkeypatch):
+        """Full create + undo cycle restores dirty state inside a worktree."""
+        monkeypatch.chdir(worktree)
+        (worktree / "file.txt").write_text("wt edit\n")
+
+        create_undo_point()
+
+        (worktree / "file.txt").write_text("agent edit\n")
+        _git(worktree, "add", ".")
+        _git(worktree, "commit", "-q", "-m", "agent")
+
+        undo()
+
+        assert (worktree / "file.txt").read_text() == "wt edit\n"
+        assert _git(worktree, "symbolic-ref", "--short", "HEAD") == "wt-branch"
+
+    @pytest.mark.unit
+    def test_state_files_in_per_worktree_git_dir(self, repo, worktree, monkeypatch):
+        """Lock and undo states go to .git/worktrees/<name>/, not the .git file."""
+        monkeypatch.chdir(worktree)
+
+        create_undo_point()
+
+        wt_git_dir = repo / ".git" / "worktrees" / "wt"
+        assert (wt_git_dir / "scrappy" / "undo-states.json").exists()
+        # Lock is released after the operation
+        assert not (wt_git_dir / "scrappy.lock").exists()
+
+    @pytest.mark.unit
+    def test_merge_detected_in_worktree(self, repo, worktree, monkeypatch):
+        """
+        An active merge inside a worktree blocks undo point creation.
+
+        MERGE_HEAD lives in the per-worktree git dir. Old code probed
+        '.git/MERGE_HEAD', which never exists in a worktree, so an active
+        merge went undetected.
+        """
+        monkeypatch.chdir(worktree)
+        (repo / ".git" / "worktrees" / "wt" / "MERGE_HEAD").write_text("deadbeef\n")
+
+        with pytest.raises(UndoError, match="merge"):
+            check_undo_preconditions()
+
+    @pytest.mark.unit
+    def test_shallow_probe_uses_common_git_dir(self, repo, worktree, monkeypatch):
+        """
+        The shallow marker is clone-wide: it lives in the common git dir
+        and must be visible from inside a worktree.
+        """
+        monkeypatch.chdir(worktree)
+        assert not is_shallow_clone()
+
+        (repo / ".git" / "shallow").write_text("deadbeef\n")
+        assert is_shallow_clone()
+
+    @pytest.mark.unit
+    def test_undo_states_isolated_per_worktree(self, repo, worktree, monkeypatch):
+        """Undo points created in a worktree are not visible from the main clone."""
+        monkeypatch.chdir(worktree)
+        (worktree / "file.txt").write_text("wt edit\n")
+        create_undo_point()
+        assert len(load_undo_states()) == 1
+
+        monkeypatch.chdir(repo)
+        assert load_undo_states() == []


### PR DESCRIPTION
The undo module built every git metadata path from a literal ".git/" prefix relative to cwd. In a linked git worktree, .git is a file with a "gitdir:" pointer, so create_undo_point() crashed with NotADirectoryError on the lock file, and merge/rebase/cherry-pick precondition probes silently missed active operations whose state lives in the per-worktree git dir.

Resolve paths through git instead:

- git rev-parse --git-dir (per-worktree): MERGE_HEAD, REBASE_HEAD, CHERRY_PICK_HEAD, rebase-merge, rebase-apply probes, plus scrappy's lock file and undo-states.json, since an undo point captures per-worktree state (HEAD, branch, working tree).
- git rev-parse --git-common-dir (shared): the shallow marker, a clone-wide property.

In a normal clone both resolve to .git, so file locations and behavior there are unchanged.

Tests: tests/test_undo_git_layouts.py exercises real git repos in both layouts; the worktree tests fail on the previous code with the exact reproduced error. Existing unit tests now patch the path resolver functions instead of the removed module constants, and the over-mocked precondition/shallow tests were rewritten as behavior tests.

Fixes scrappy-undo-broken-in-git-worktrees-aqzv.