### PR TITLE
PR-2a: ModelAvailabilityTrackerProtocol seam for model selection

### DIFF
--- a/src/scrappy/orchestrator/factory.py
+++ b/src/scrappy/orchestrator/factory.py
@@ -44,7 +44,11 @@ from .litellm_config import create_litellm_router
 # NOTE: litellm_callbacks imports litellm at top level, so we import it lazily
 # in create_llm_service() to avoid 2s startup delay
 from .provider_status import ProviderStatusTracker
-from .model_selection import ModelSelectionService, ModelSelectionServiceProtocol
+from .model_selection import (
+    ModelAvailabilityTracker,
+    ModelSelectionService,
+    ModelSelectionServiceProtocol,
+)
 from .manager_protocols import (
     ContextManagerProtocol,
     BackgroundTaskManagerProtocol,
@@ -457,7 +461,10 @@ class OrchestratorFactory:
 
         api_key_service = create_api_key_service()
         configured_models = self._get_configured_models(api_key_service)
-        return ModelSelectionService(configured_models=configured_models)
+        return ModelSelectionService(
+            configured_models=configured_models,
+            availability_tracker=ModelAvailabilityTracker(),
+        )
 
     def _get_configured_models(self, api_key_service) -> set[str]:
         """

--- a/src/scrappy/orchestrator/model_selection.py
+++ b/src/scrappy/orchestrator/model_selection.py
@@ -148,6 +148,41 @@ class ModelHealthState:
     retry_after: Optional[float] = None
 
 
+class ModelAvailabilityTrackerProtocol(Protocol):
+    """
+    Selection-facing contract for the model availability/cooldown store.
+
+    This is the honest minimal surface ModelSelectionService consumes; it does
+    not mirror the concrete tracker. clear() and get_available() have no
+    selection caller and stay off the protocol. Selection depends on this
+    protocol, never on a concrete tracker or a persistence detail.
+    """
+
+    def now(self) -> float:
+        """Return the tracker's clock value (used to compute expiry)."""
+        ...
+
+    def mark(self, model: str, state: ModelHealthState) -> None:
+        """Store resolved health state for a model."""
+        ...
+
+    def is_available(self, model: str) -> bool:
+        """Return whether a model is currently available (no live cooldown)."""
+        ...
+
+    def get_cooldown_remaining(self, model: str) -> float:
+        """Return seconds of cooldown remaining for a model, or 0.0."""
+        ...
+
+    def get_unavailable_state(self, model: str) -> Optional[ModelHealthState]:
+        """Return current health state for a model, clearing expired entries."""
+        ...
+
+    def clear_kinds(self, kinds: set[FailureKind]) -> None:
+        """Clear health states matching any of the given failure kinds."""
+        ...
+
+
 class ModelAvailabilityTracker:
     """
     Track temporary model health states with automatic recovery.
@@ -326,7 +361,7 @@ class ModelSelectionService:
         self,
         configured_models: set[str],
         model_priorities: Optional[dict[ModelSelectionType, list[str]]] = None,
-        availability_tracker: Optional[ModelAvailabilityTracker] = None,
+        availability_tracker: Optional[ModelAvailabilityTrackerProtocol] = None,
     ):
         """
         Initialize model selection service.
@@ -342,7 +377,9 @@ class ModelSelectionService:
         self._configured = set(configured_models)
         self._configured_lock = threading.Lock()
         self._priorities = model_priorities or MODEL_PRIORITIES
-        self._availability = availability_tracker or ModelAvailabilityTracker()
+        self._availability: ModelAvailabilityTrackerProtocol = (
+            availability_tracker or ModelAvailabilityTracker()
+        )
 
     def select(
         self,

--- a/tests/orchestrator/test_model_selection_availability_protocol.py
+++ b/tests/orchestrator/test_model_selection_availability_protocol.py
@@ -1,0 +1,139 @@
+"""PR-2a: selection depends on ModelAvailabilityTrackerProtocol, not a concrete.
+
+These tests inject a fake availability store that conforms to the protocol (and
+is NOT the concrete ModelAvailabilityTracker) into ModelSelectionService, then
+assert selection consumes the protocol and preserves priority ordering. They are
+the executable contract for the PR-2a decoupling seam; PR-2b (persisted
+cooldowns) builds on the same seam and must not change this behavior.
+"""
+
+from typing import Optional
+
+from scrappy.infrastructure.exceptions.failure_kinds import FailureKind
+from scrappy.orchestrator.model_selection import (
+    ModelAvailabilityTrackerProtocol,
+    ModelHealthState,
+    ModelSelectionService,
+    ModelSelectionType,
+)
+
+# groq is first, cerebras second in MODEL_PRIORITIES[FAST] (see existing
+# test_model_selection.py assertions).
+GROQ = "groq/llama-3.1-8b-instant"
+CEREBRAS = "cerebras/llama3.1-8b"
+FAST_MODELS = {GROQ, CEREBRAS}
+
+
+class FakeAvailabilityStore:
+    """In-test availability store implementing the protocol surface only.
+
+    Availability is driven directly by ``unavailable`` so a test controls it
+    without the concrete cooldown/clock machinery. Its only job is to prove
+    selection talks to the protocol rather than to a concrete type.
+    """
+
+    def __init__(self, unavailable: Optional[set[str]] = None) -> None:
+        self.unavailable: set[str] = set(unavailable or set())
+        self.marked: dict[str, ModelHealthState] = {}
+        self.cleared_kinds: list[set[FailureKind]] = []
+
+    def now(self) -> float:
+        return 1000.0
+
+    def mark(self, model: str, state: ModelHealthState) -> None:
+        self.marked[model] = state
+        self.unavailable.add(model)
+
+    def is_available(self, model: str) -> bool:
+        return model not in self.unavailable
+
+    def get_cooldown_remaining(self, model: str) -> float:
+        return 0.0
+
+    def get_unavailable_state(self, model: str) -> Optional[ModelHealthState]:
+        return self.marked.get(model)
+
+    def clear_kinds(self, kinds: set[FailureKind]) -> None:
+        self.cleared_kinds.append(set(kinds))
+        self.unavailable.clear()
+
+
+def test_fake_store_conforms_to_protocol():
+    """The fake satisfies the protocol surface (also a static mypy check)."""
+    store: ModelAvailabilityTrackerProtocol = FakeAvailabilityStore()
+    assert store.is_available(GROQ)
+
+
+class TestSelectionConsumesAvailabilityProtocol:
+    """Selection reads availability through the injected protocol."""
+
+    def test_skips_model_the_protocol_reports_unavailable(self):
+        """Highest-priority model is skipped when the protocol says unavailable."""
+        store = FakeAvailabilityStore(unavailable={GROQ})
+        service = ModelSelectionService(
+            configured_models=FAST_MODELS,
+            availability_tracker=store,
+        )
+
+        assert service.select(ModelSelectionType.FAST) == CEREBRAS
+
+    def test_includes_model_when_protocol_reports_available(self):
+        """Highest-priority model is chosen when the protocol says available."""
+        store = FakeAvailabilityStore(unavailable=set())
+        service = ModelSelectionService(
+            configured_models=FAST_MODELS,
+            availability_tracker=store,
+        )
+
+        assert service.select(ModelSelectionType.FAST) == GROQ
+
+    def test_clear_failure_kinds_delegates_to_protocol(self):
+        """clear_failure_kinds routes to the protocol's clear_kinds."""
+        store = FakeAvailabilityStore(unavailable={GROQ})
+        service = ModelSelectionService(
+            configured_models=FAST_MODELS,
+            availability_tracker=store,
+        )
+
+        service.clear_failure_kinds({FailureKind.RATE_LIMIT})
+
+        assert store.cleared_kinds == [{FailureKind.RATE_LIMIT}]
+        assert service.select(ModelSelectionType.FAST) == GROQ
+
+
+class TestOrderingPreserved:
+    """Guards against an accidental reorder/semantics change in filtering."""
+
+    def test_priority_order_preserved_among_available_models(self):
+        """First available candidate is the highest-priority available model."""
+        store = FakeAvailabilityStore(unavailable=set())
+        service = ModelSelectionService(
+            configured_models=FAST_MODELS,
+            availability_tracker=store,
+        )
+
+        assert service.select(ModelSelectionType.FAST) == GROQ
+        ordered = service.get_models_for_type(ModelSelectionType.FAST)
+        assert ordered.index(GROQ) < ordered.index(CEREBRAS)
+
+    def test_session_preferred_wins_only_when_it_survives_filtering(self):
+        """session_preferred wins iff available; otherwise priority order holds."""
+        available = FakeAvailabilityStore(unavailable=set())
+        service = ModelSelectionService(
+            configured_models=FAST_MODELS,
+            availability_tracker=available,
+        )
+        assert (
+            service.select(ModelSelectionType.FAST, session_preferred=CEREBRAS)
+            == CEREBRAS
+        )
+
+        blocked = FakeAvailabilityStore(unavailable={CEREBRAS})
+        service_blocked = ModelSelectionService(
+            configured_models=FAST_MODELS,
+            availability_tracker=blocked,
+        )
+        assert (
+            service_blocked.select(ModelSelectionType.FAST, session_preferred=CEREBRAS)
+            == GROQ
+        )


### PR DESCRIPTION
Define ModelAvailabilityTrackerProtocol (the honest six-member surface ModelSelectionService consumes: now, mark, is_available, get_cooldown_remaining, get_unavailable_state, clear_kinds) and make the service depend on the protocol instead of the concrete ModelAvailabilityTracker. The factory now injects the concrete tracker as the production default; the __init__ fallback is retained for direct construction.

clear() and get_available() are deliberately kept off the protocol: no production selection caller (grep-proven). Pure decoupling seam, zero behavior change. Persisted cooldowns are PR-2b, out of scope here.

Verification (four-check vs postM5c baseline): mypy 103, set-diff 0 removals / 0 additions; import walk 294 modules / 0 failures; collect 5137 -> 5143 (6 declared new tests); ruff clean; full default suite 5035 passed / 2 skipped / 0 failures.

Plan: .docs/plans/provider-pr2-guardrails.md (rev 3, cross-family reviewed). Bead: scrappy-health-signal-unification-9nah.