### PR TITLE
Protocol honesty round 3: declare members implementers already have

### DIFF
--- a/src/scrappy/agent_tools/tools/base.py
+++ b/src/scrappy/agent_tools/tools/base.py
@@ -143,20 +143,24 @@ class WorkingSet:
             del self._files[oldest_path]
 
 
+class ToolWorkingMemoryProtocol(Protocol):
+    """Exactly the working-memory operations ToolContext performs.
+
+    Deliberately minimal and uniquely named: two unrelated protocols are both
+    named WorkingMemoryProtocol (graph vs orchestrator flavours, see
+    scrappy-x8up), and neither matches what the tool layer actually needs.
+    """
+
+    def remember_file_read(self, path: str, content: str, lines: int = 0) -> None: ...
+    def remember_search(self, query: str, results: list) -> None: ...
+    def remember_git_operation(self, operation: str, output: str) -> None: ...
+
+
 class MemoryProvider(Protocol):
-    """Protocol for memory operations in tools."""
+    """Protocol for the object ToolContext reaches working memory through."""
 
-    def remember_file_read(self, path: str, content: str, lines: int) -> None:
-        """Store file read in working memory."""
-        ...
-
-    def remember_search(self, query: str, results: list) -> None:
-        """Store search results in working memory."""
-        ...
-
-    def remember_git_operation(self, operation: str, result: str) -> None:
-        """Store git operation result in working memory."""
-        ...
+    @property
+    def working_memory(self) -> ToolWorkingMemoryProtocol: ...
 
 
 def _default_agent_config() -> "AgentConfig":

--- a/src/scrappy/context/protocols.py
+++ b/src/scrappy/context/protocols.py
@@ -5,11 +5,24 @@ Defines abstract interfaces for codebase context awareness, project detection,
 file scanning, and git history operations.
 """
 
-from typing import Callable, Protocol, Dict, Any, List, Optional, Set, runtime_checkable
+from typing import (
+    Callable,
+    Protocol,
+    Dict,
+    Any,
+    List,
+    Optional,
+    Set,
+    runtime_checkable,
+    TYPE_CHECKING,
+)
 from pathlib import Path
 from datetime import datetime
 from dataclasses import dataclass
 from enum import Enum
+
+if TYPE_CHECKING:
+    from scrappy.infrastructure.protocols import ProgressReporterProtocol
 
 
 @runtime_checkable
@@ -785,6 +798,11 @@ class FileCollectorProtocol(Protocol):
     """
     Protocol for collecting files for semantic search indexing.
 
+    Defined as the full indexing collector contract: file collection PLUS
+    file metadata (paths, content hashes, sizes). This is a deliberate design
+    choice made visible here at the definition rather than buried in a plan,
+    so consumers see that an indexing collector owns both responsibilities.
+
     Abstracts file collection to enable:
     - File size limits to prevent OOM
     - Binary file detection
@@ -830,6 +848,23 @@ class FileCollectorProtocol(Protocol):
             Dict[str, str]: Batch of file paths to content
         """
         ...
+
+    def collect_file_paths(self) -> List[Path]: ...
+    def get_file_hashes(self, files: List[Path]) -> Dict[str, str]: ...
+    def get_file_sizes(self, files: List[Path]) -> Dict[str, int]: ...
+
+
+@runtime_checkable
+class IndexingSearchProtocol(SemanticSearchProtocol, Protocol):
+    """Search provider that also owns index persistence and progress wiring.
+
+    Capability composite used by SemanticSearchManager only. General search
+    consumers depend on SemanticSearchProtocol and must not be forced to
+    implement persistence or progress reporting.
+    """
+
+    def save_index_state(self, state_manager: 'IndexStateProtocol') -> None: ...
+    def set_progress_reporter(self, progress_reporter: 'ProgressReporterProtocol') -> None: ...
 
 
 @runtime_checkable
@@ -978,6 +1013,8 @@ class SemanticSearchManagerProtocol(Protocol):
             timeout: Max seconds to wait for background threads to stop.
         """
         ...
+
+    def get_search_provider(self) -> Optional['SemanticSearchProtocol']: ...
 
 
 @runtime_checkable
@@ -1271,6 +1308,9 @@ class StalenessCheckerProtocol(Protocol):
         Should be called after successfully re-indexing changed files.
         """
         ...
+
+    def has_fingerprints(self) -> bool: ...
+    def quick_check(self) -> bool: ...
 
 
 # --- Re-index Operations ---

--- a/src/scrappy/context/semantic_manager.py
+++ b/src/scrappy/context/semantic_manager.py
@@ -24,7 +24,7 @@ from ..infrastructure.threading import (
     EventType,
 )
 from .protocols import (
-    SemanticSearchProtocol,
+    IndexingSearchProtocol,
     FileCollectorProtocol,
     SearchResult,
     IndexStateProtocol,
@@ -93,7 +93,7 @@ class SemanticSearchManager:
         self._staleness_checker = staleness_checker or self._create_default_staleness_checker()
 
         # Semantic search state
-        self._semantic_search: Optional[SemanticSearchProtocol] = None
+        self._semantic_search: Optional[IndexingSearchProtocol] = None
         self._initializer = initializer
         self._progress_callback: Optional[Callable[[str, int, int], None]] = None
         self._file_collector_callback: Optional[Callable[[], Optional[FileCollectorProtocol]]] = None
@@ -264,7 +264,7 @@ class SemanticSearchManager:
             return self._initializer.get_status()
         return None
 
-    def get_search_provider(self) -> Optional[SemanticSearchProtocol]:
+    def get_search_provider(self) -> Optional[IndexingSearchProtocol]:
         """
         Get the semantic search provider if available.
 

--- a/src/scrappy/infrastructure/protocols.py
+++ b/src/scrappy/infrastructure/protocols.py
@@ -742,6 +742,8 @@ class BackgroundInitializerProtocol(Protocol):
         """
         ...
 
+    def shutdown(self, timeout: float = 5.0) -> bool: ...
+
 
 class ProgressReporterProtocol(Protocol):
     """


### PR DESCRIPTION
Repairs static contracts only. Zero behavioral change, zero new tests. mypy 96 -> 81 (15 attr-defined removals, 0 additions).

Every added member is backed by a production implementer at that exact signature; no capability is invented.

A1 StalenessCheckerProtocol +has_fingerprints/+quick_check
   (staleness.py:192,204). Kills 3.
A2 FileCollectorProtocol +collect_file_paths/+get_file_hashes/
   +get_file_sizes, implemented identically by both production
   collectors. The docstring now states that this protocol is defined as
   the full indexing collector contract, so the design choice is visible
   at the definition rather than buried in a plan. Kills 3.
A3 SemanticSearchManagerProtocol +get_search_provider, deliberately
   returning the NARROW Optional[SemanticSearchProtocol] view. Kills 1.
B1 New IndexingSearchProtocol capability composite carrying
   save_index_state and set_progress_reporter, owned by
   SemanticSearchManager alone. SemanticSearchProtocol is consumed
   broadly and is deliberately NOT widened, so search-only consumers and
   test doubles are never forced to implement persistence or progress
   wiring. Kills 4.
B2 BackgroundInitializerProtocol +shutdown(timeout: float = 5.0) -> bool.
   Returns bool because the call site consumes it: semantic_manager.py
   assigns the result and branches on it. Kills 1.
C1 New minimal ToolWorkingMemoryProtocol, and MemoryProvider reduced to a
   read-only working_memory property. Kills 3, and also REMOVES the
   fictional remember_file_read/remember_search/remember_git_operation
   trio from MemoryProvider: grep proves no caller reaches it through a
   MemoryProvider-typed reference, and the trio's old signatures did not
   even match the real implementer. The protocol gets strictly narrower,
   so every current implementer still satisfies it.

Deliberately NOT fixed, same error shape but no implementer exists: FormatterOutputProtocol.use_color (scrappy-z708) and CommandHistoryProtocol.prompt_with_history (scrappy-qdyz). Those are latent runtime bugs and must be fixed as behaviour, never typed away.

Verified independently at the architect seat:
  mypy      81 errors in 28 files (296 checked); set-diff vs the
            96-error baseline is exactly 15 removed, 0 added
  imports   modules=294 failures=0
  collect   5279 tests, zero new
  ruff      clean on all 4 touched files
  suite     5171 passed, 2 skipped